### PR TITLE
feat : 반응형 footer 생성 [#1]

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,27 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,7 +1,164 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
 export default function Footer() {
   return (
-    <>
-      <h1>Footer</h1>
-    </>
+    <footer className="bg-main-beige">
+      {/* 모바일 섹션 */}
+      <div className="flex flex-col items-center gap-4 md:hidden px-8 py-8">
+        {/* 모바일 Footer 전용 버튼 */}
+        <div className="relative w-[100px] h-8 bg-white rounded-[5px] shadow flex items-center">
+          <Link href="/about" className="absolute inset-0 flex items-center">
+            <span className="text-[10px] font-medium pl-[9px]">
+              토마토들 소개 →
+            </span>
+          </Link>
+          <div className="absolute right-0 bottom-0 flex items-end">
+            <Image
+              src="/assets/common/MO_button_t.svg"
+              alt="토마토들 소개 버튼 토마토 이미지"
+              width={24}
+              height={24}
+            />
+          </div>
+        </div>
+        {/* 모바일 Footer 하단 섹션*/}
+        <div className="flex flex-col items-center gap-2">
+          <div className="flex gap-4">
+            <Link href="/" className="underline text-xs">
+              공지사항
+            </Link>
+            <Link href="/" className="underline text-xs">
+              FAQ
+            </Link>
+            <Link href="/" className="underline text-xs">
+              1:1 문의
+            </Link>
+          </div>
+          <div className="flex gap-4">
+            <Link href="/" className="underline text-xs">
+              이용약관
+            </Link>
+            <Link href="/" className="underline text-xs">
+              개인정보처리방침
+            </Link>
+            <Link href="/" className="underline text-xs">
+              책임한계와 법적고지
+            </Link>
+          </div>
+        </div>
+        <div className="text-xs text-center">
+          Copyright ©Tomato.DLE. All Rights Reserved.
+        </div>
+        <div className="mt-2">
+          <Image
+            src="/assets/common/MO_logo_text.svg"
+            alt="토마토들 로고 모바일"
+            width={78}
+            height={18}
+          />
+        </div>
+      </div>
+
+      {/* PC 섹션 */}
+      <div className="hidden md:flex flex-col h-[536px] px-[84px] py-16 justify-start items-start gap-2.5">
+        <div className="flex justify-between items-start w-full h-[408px] gap-[72px]">
+          {/* 좌측 섹션 */}
+          <div className="flex justify-start items-start gap-[88px]">
+            <div className="flex flex-col justify-start items-start gap-6">
+              <div>TOMATO.DLE</div>
+              <div className="h-[216px] flex flex-col justify-start items-start gap-6">
+                <Link href="/" className="font-semibold">
+                  토마토들 소개
+                </Link>
+                <Link href="/magazine" className="font-semibold">
+                  매거진
+                </Link>
+                <Link href="/contest" className="font-semibold">
+                  공모전
+                </Link>
+                <Link href="/activity" className="font-semibold">
+                  대외활동
+                </Link>
+                <Link href="/talk" className="font-semibold">
+                  교육•강연
+                </Link>
+              </div>
+            </div>
+            <div className="flex flex-col justify-start items-start gap-6">
+              <div>광고등록/문의</div>
+              <div className="h-[120px] flex flex-col justify-start items-start gap-6">
+                <Link href="/cs" className="font-semibold">
+                  사업소개
+                </Link>
+                <Link href="/cs" className="font-semibold">
+                  광고문의
+                </Link>
+                <Link href="/cs" className="font-semibold">
+                  대행문의
+                </Link>
+              </div>
+            </div>
+            <div className="flex flex-col justify-start items-start gap-6">
+              <div>고객문의</div>
+              <div className="h-[120px] flex flex-col justify-start items-start gap-6">
+                <Link href="/" className="font-semibold">
+                  공지사항
+                </Link>
+                <Link href="/" className="font-semibold">
+                  FAQ
+                </Link>
+                <Link href="/" className="font-semibold">
+                  1:1 문의
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          {/* 우측 섹션 (로고와 인스타그램) */}
+          <div className="flex flex-col justify-start items-end gap-8">
+            <div>
+              <Image
+                src="/assets/common/PC_logo_text.svg"
+                alt="토마토들 로고"
+                width={78}
+                height={18}
+              />
+            </div>
+            <div>
+              <Link href="https://www.instagram.com" target="_blank">
+                <Image
+                  src="/assets/common/PC_Instagram.svg"
+                  alt="Instagram 아이콘"
+                  width={31}
+                  height={32}
+                />
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* 하단 법적 정보 섹션 */}
+        <div className="flex flex-col justify-start items-start gap-6 h-[72px] w-full">
+          <div className="flex justify-start items-center gap-10">
+            <div>Copyright ©Tomato.DLE. All Rights Reserved.</div>
+            <div>사업자등록번호 000-00000-00000</div>
+            <div>주소: 구로구 가마산로 242 3층 306,7호</div>
+            <div>대표: 고경표</div>
+          </div>
+          <div className="flex justify-start items-center gap-10">
+            <Link href="/" className="underline">
+              이용약관
+            </Link>
+            <Link href="/" className="underline">
+              개인정보처리방침
+            </Link>
+            <Link href="/" className="underline">
+              책임한계와 법적고지
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
   );
 }


### PR DESCRIPTION
## 변경 사항 설명
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요. -->
토마토들 서비스에서 사용될 하단 footer의 반응형 레이아웃 구현

![스크린샷 2024-10-15 145132](https://github.com/user-attachments/assets/3fd44a78-3100-49d4-8477-63ea02ab02ec)
![스크린샷 2024-10-15 145143](https://github.com/user-attachments/assets/1ec9f2f8-464c-4918-beb0-c3f0f8a8177d)

## 관련 이슈
#1 

## 변경 유형
- [ ] 새로운 기능 : 공통으로 사용될 반응형 footer 레이아웃 작업


## 체크리스트
<!--PR 체크리스트에 어떤 내용이 들어가면 좋을지 논의해 봅시다.-->
- [ ] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [ ] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
<!-- PR에 대한 추가 정보나 스크린샷이 있다면 여기에 추가해주세요. -->
현재 footer에 있는 여러 메뉴의 링크가 아직 확정되지 않았습니다. 그래서 현재 대부분의 링크는 '/'로 연결되어 있습니다. 추후 기능이 구현되면, 각 메뉴 항목에 맞는 링크로 수정해야 합니다.