### PR TITLE
Design: 공용 컴포넌트 레이아웃 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,47 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
+  }
+}
+
+@layer components {
+  .header-navigation-container {
+    @apply flex flex-1 items-center fixed md:static bottom-[30px] left-1/2 transform -translate-x-1/2 md:transform-none;
+  }
+
+  .header-navigation-list {
+    @apply flex gap-6 lg:gap-10 bg-white h-full px-8 md:px-0 py-4 md:py-0 whitespace-nowrap shadow md:shadow-none border md:border-none border-sub-gray-100 rounded-full md:rounded-none items-center;
+  }
+
+  .header-nav-item {
+    @apply relative text-sm md:text-base lg:text-2xl font-medium lg:font-semibold box-border border-b-0 md:border-b-2;
+  }
+
+  .header-active {
+    @apply text-sub-gray-500 border-point-green-500;
+  }
+
+  .header-inactive {
+    @apply text-sub-gray-200 border-transparent;
+  }
+
+  .header-has-new-content {
+    @apply absolute top-1 -right-2 inline-block w-[5px] h-[5px] bg-point-red-500 rounded-full;
+  }
+
+  .header-link-item {
+    @apply whitespace-nowrap text-base lg:text-xl font-medium lg:font-semibold rounded-full py-2 px-3;
+  }
+
+  .header-active-link {
+    @apply bg-sub-yellow-500 text-sub-gray-500;
+  }
+
+  .header-inactive-link {
+    @apply bg-sub-yellow-100 text-sub-gray-400;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
+import Header from '@/components/ui/Header';
+import Footer from '@/components/common/Footer';
 
 const pretendard_var = localFont({
   src: '../../public/fonts/pretendard_variable.woff2',
@@ -19,7 +21,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${pretendard_var.className}`}>{children}</body>
+      <body className={`${pretendard_var.className}`}>
+        <Header />
+        {children}
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/src/components/common/BannerLink.tsx
+++ b/src/components/common/BannerLink.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default function BannerLink({ url }: { url: string }) {
+  return (
+    <Link
+      href={url}
+      className="
+        text-main-beige rounded-[5px] hover:bg-opacity-90 bg-point-green-500 text-center flex flex-row gap-2.5 items-center justify-center 
+        md:w-[140px] md:h-[42px] md:text-base
+        w-[100px] h-8 text-sm
+        lg:w-40 lg:h-[52px] lg:text-xl
+      "
+    >
+      자세히보기
+    </Link>
+  );
+}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,0 +1,31 @@
+import Navigation from './Navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="flex items-center px-7 py-4 lg:px-[88px] lg:py-[22px] justify-between w-full shadow">
+      <Link href="/" className="mr-8 shrink-0">
+        {/* 데스크탑 로고 */}
+        <Image
+          src="/assets/common/PC_logo_text (1).svg"
+          width={160}
+          height={30}
+          alt="tomatoes desktop logo"
+          className="hidden md:block"
+        />
+
+        {/* 모바일 로고 */}
+        <Image
+          src="/assets/common/MO_logo_text.svg"
+          width={76}
+          height={17}
+          alt="tomatoes mobile logo"
+          className="md:hidden block"
+        />
+      </Link>
+
+      <Navigation />
+    </header>
+  );
+}

--- a/src/components/ui/NavItem.tsx
+++ b/src/components/ui/NavItem.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+type navItemType = {
+  name: string;
+  route: string;
+  hasNewContent: boolean;
+};
+
+export default function NavItem({
+  name,
+  route,
+  isActive,
+  hasNewContent,
+}: navItemType & { isActive: boolean }) {
+  return (
+    <li
+      className={`header-nav-item ${isActive ? 'header-active' : 'header-inactive'}`}
+    >
+      <Link href={route}>
+        {name}
+        {hasNewContent && <span className="header-has-new-content"></span>}
+      </Link>
+    </li>
+  );
+}

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import NavItem from './NavItem';
+
+type navItemType = {
+  name: string;
+  route: string;
+  hasNewContent: boolean; // 새로운 콘텐츠 여부
+};
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  const navItems: navItemType[] = [
+    { name: '매거진', route: '/magazine', hasNewContent: true },
+    { name: '공모전', route: '/contest', hasNewContent: false },
+    { name: '대외활동', route: '/activity', hasNewContent: false },
+    { name: '교육・강연', route: '/talk', hasNewContent: false },
+  ];
+
+  return (
+    <nav className="header-navigation-container z-50">
+      <ul className="header-navigation-list">
+        {navItems.map((item) => {
+          const isActive = pathname === item.route;
+          return <NavItem key={item.name} {...item} isActive={isActive} />;
+        })}
+        <li className="hidden md:block">
+          <Link
+            href="/cs"
+            className={`header-link-item ${
+              pathname === '/cs' ? 'header-active-link' : 'header-inactive-link'
+            }`}
+          >
+            공고등록/문의
+          </Link>
+        </li>
+      </ul>
+      <Image
+        src="/assets/common/MO_nav_t.svg"
+        width={36}
+        height={38}
+        alt=""
+        className="block md:hidden absolute right-8 bottom-12 z-[-1]"
+        aria-disabled="true"
+      />
+    </nav>
+  );
+}


### PR DESCRIPTION
# 변경 사항 설명
본 PR에서는 토마토들 서비스에서 사용될 헤더 및 내비게이션 바의 레이아웃을 및 배너 링크 컴포넌트를 구현했습니다.

## 배너 링크 컴포넌트
기존의 `Button.tsx` 컴포넌트는 페이지 전역에서 사용되는 것이 아닌, 홈 화면의 배너에서만 사용되고 있습니다. 그러나 디자인 시스템에서는 Button으로 표시되어 있어 혼동의 여지가 있습니다.

일반적으로 Button 컴포넌트는 **사용자와의 상호작용**을 담당하고, Link 컴포넌트는 **페이지 간의 이동**을 담당하기 때문에, 홈 화면의 배너를 클릭했을 때 해당 대외활동 정보의 상세 페이지로 이동하게 하는 기능을 가진 위 컴포넌트는 Link를 사용하는 것이 더 적절하다고 판단되어 Link 컴포넌트로 구현했습니다.

- 컴포넌트에 url props를 넘겨 해당하는 페이지로 이동할 수 있도록 구현했습니다.
- 반응형 디자인을 적용했습니다.

```tsx
import Link from 'next/link';

export default function BannerLink({ url }: { url: string }) {
  return (
    <Link
      href={url}
      className="
        text-[#F5F1DE] rounded-[5px] hover:bg-opacity-90 bg-[#4A734E] text-center flex flex-row gap-2.5 items-center justify-center 
        md:w-[140px] md:h-[42px] md:text-base
        w-[100px] h-8 text-sm
        lg:w-40 lg:h-[52px] lg:text-xl
      "
    >
      자세히보기
    </Link>
  );
}
```

## 내비게이션 컴포넌트
### `Navigation.tsx`
내비게이션 컴포넌트는 스크린 크기에 따른 재사용성을 염두하여 설계됐습니다. 피그마 시안에서 확인할 수 있는 것처럼, 해당 컴포넌트는 데스크탑 환경에서는 헤더 내부에 위치하다가, 모바일 환경에서는 뷰포트 기준 하단에 위치하게 됩니다. 따라서 이를 고려해 스크린 사이즈에 따라 위치가 조절되도록 구현했습니다.

- 또한 `공고등록/문의` 링크의 경우 모바일 환경에서는 보이지 않도록 처리해야 하기 때문에 `<ul>` 요소 외부에서 구현했습니다.

- 내비게이션 바에 사용되는 토마토 이미지의 경우, 꾸밈을 위한 이미지이기 때문에 스크린 리더가 읽지 않도록 해야 합니다. 따라서 `aria-disabled` 속성을 사용해 이를 처리했습니다.

### `NavItem.tsx`
내비게이션 아이템 컴포넌트는 현재 다음과 같은 props를 받습니다.
```ts
export default function NavItem({
  name,
  route,
  isActive,
  hasNewContent,
}: navItemType & { isActive: boolean }) {
  return (
        // 생략된 컴포넌트
  );
}
```
이 중 `hasNewContent`의 경우 새로운 콘텐츠가 해당 카테고리에 추가되면 이를 확인하고 표시할 수 있도록 하기 위함이며, 현재는 API가 연결되지 않아 임의의 더미데이터로 처리했습니다. 추후 API 연동이 진행되면 해당 부분에 대한 기능을 추가할 예정입니다.

## 헤더 컴포넌트
- 헤더 컴포넌트는 데스크톱/모바일 환경에 따라 보여야 하는 로고 이미지가 각각 다르기에, 해당 부분을 고려하여 처리했습니다.
- 헤더 컴포넌트는 토마토들 서비스의 모든 페이지에서 사용되기 때문에, 루트 레이아웃 컴포넌트에 추가했습니다.

### 컴포넌트 분리
- ui에 사용되는 컴포넌트는 ui라는 폴더를 생성하고, 해당 폴더 내에서 관리할 수 있도록 했습니다. 추후 수정이 필요할 경우 변경될 수 있습니다.

# 구현 결과
이미지 클릭 시 보다 큰 화면에서 확인할 수 있습니다.
| 반응형 확인 |
|-------------|
| ![반응형-확인](https://github.com/user-attachments/assets/577e840c-dbfb-4a7c-a9bc-eee8e04e5ee7) |        |

| 헤더(데스크탑) | 헤더(모바일) |
|----------------|--------------|
| ![데스크톱-링크-확인](https://github.com/user-attachments/assets/8e8db73d-0cd3-40c4-ad0d-915d23d1445c) | ![모바일-링크-확인](https://github.com/user-attachments/assets/3d084d6e-3ea5-4ccf-a2b6-3bc1c00c9cfe) |

## 관련 이슈
#7 

## 변경 유형
- [ x ] 새로운 컴포넌트 레이아웃

## 체크리스트
- [ x ] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [ x ] 필요한 경우, 주석을 추가했습니다.