### PR TITLE
Feat: 매거진 컴포넌트 불러오기, 더보기 버튼 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,9 @@ import PaginationForHome from '@/components/ui/pagination/PaginationForHome';
 import Image from 'next/image';
 import ContestCardSlider from '@/components/ui/homePage/ContestCardSlider';
 import ActivityCardSlider from '@/components/ui/homePage/ActivityCardSlider';
+import TomatoTips from './magazine/components/TomatoTips';
+import { AiOutlineRight } from 'react-icons/ai';
+import Link from 'next/link';
 
 export default function Home() {
   const dummyActivities: Activity[] = Array.from({ length: 80 }, (_, i) => ({
@@ -45,20 +48,47 @@ export default function Home() {
 
       {/* 공모전 */}
       <section className="mt-10">
-        <p className="ml-8 text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">공모전</p>
+        <div className="flex flex-row justify-between">
+          <p className="ml-8 text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">공모전</p>
+          <Link
+            href={'/contest'}
+            className="flex flex-row items-center gap-1 mr-10"
+          >
+            더보기
+            <AiOutlineRight />
+          </Link>
+        </div>
         <ContestCardSlider />
       </section>
 
       {/* 대외활동 */}
       <section className="mt-10">
-        <p className="ml-8 text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">대외활동</p>
+        <div className="flex flex-row justify-between">
+          <p className="ml-8 text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">대외활동</p>
+          <Link 
+          href={'/activity'}
+            className="flex flex-row items-center gap-1 mr-10"
+          >
+            더보기
+            <AiOutlineRight />
+          </Link>
+        </div>
         <ActivityCardSlider />
       </section>
 
       {/* 매거진 */}
-      <section className="mt-10">
-        <p className="text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">매거진</p>
-        <p>매거진 파트</p>
+      <section className="mt-10 ml-8">
+        <div className="flex flex-row justify-between">
+          <p className="text-[28px] md:text-[32px] font-normal font-recipe leading-[48px]">매거진</p>
+          <Link 
+            href={'/magazine'}
+            className="flex flex-row items-center gap-1 mr-10"
+          >
+            더보기
+            <AiOutlineRight />
+          </Link>
+        </div>
+        <TomatoTips pageSize={3} showPagination={false} />
       </section>
     </>
   );

--- a/src/components/ui/homePage/ActivityCardSlider.tsx
+++ b/src/components/ui/homePage/ActivityCardSlider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { AiOutlineLeftCircle, AiOutlineRightCircle } from "react-icons/ai";
+import { AiOutlineLeftCircle, AiOutlineRightCircle, AiOutlineRight } from "react-icons/ai";
 import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 


### PR DESCRIPTION
## 변경 사항 설명
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요. -->
- 매거진 컴포넌트 불러오기
- 더보기 버튼 구현

## 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. (예: #123) -->
#30 

## 변경 유형
- [X] 새로운 기능

## 체크리스트
<!--PR 체크리스트에 어떤 내용이 들어가면 좋을지 논의해 봅시다.-->
- [X] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [X] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
<!-- PR에 대한 추가 정보나 스크린샷이 있다면 여기에 추가해주세요. -->
<img width="1227" alt="Screenshot 2024-10-23 at 15 00 48" src="https://github.com/user-attachments/assets/3477114d-e871-4926-a89f-973ee0aaf3b0">

최근 merge 버전까지는 공모전 / 대외활동 / 매거진 파트에 ‘더보기’ 버튼이 구현되어 있지 않았어서 추가하였고, 
민아언니가 구현해주신 매거진 파트를 컨트롤 없이 불러와 사용했습니다 ( ◡̉̈ ) 