### PR TITLE
design: 홈 화면 전반적인 css 수정 및 크롤링 데이터와의 연결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['cf-cpi.campuspick.com'],
+  },
+};
 
 export default nextConfig;

--- a/src/components/common/Dday.tsx
+++ b/src/components/common/Dday.tsx
@@ -2,13 +2,13 @@ import Image from 'next/image';
 
 interface DdayProps {
   type: 'active' | 'completed' | 'upcoming';
-  day?: string;
+  day?: number;
   color?: 'red' | 'yellow' | 'green';
 }
 
 const baseTagStyle =
-  'w-[68px] h-[33px] md:w-[95px] md:h-[33px] p-1 rounded-[999px] justify-center items-center gap-1.5 inline-flex';
-const baseTextStyle = 'text-xs lg:text-base font-medium leading-[20px]';
+  'w-[75px] h-[33px] md:w-[95px] md:h-[33px] p-1 rounded-[999px] justify-center items-center gap-1.5 inline-flex';
+const baseTextStyle = 'text-xs sm:text-xs md:text-xs lg:text-base font-medium leading-[20px]';
 
 const tagStyles = {
   active: {

--- a/src/components/ui/grid/GridView.tsx
+++ b/src/components/ui/grid/GridView.tsx
@@ -25,14 +25,14 @@ export default function GridView<T>({
   // 커스텀 gap 정의
 
   const columnStyles = {
-    web4mobile2: 'grid-cols-2 md:grid-cols-4',
-    web3mobile1: 'grid-cols-1 md:grid-cols-3',
+    web4mobile2: 'grid-cols-2 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4',
+    web3mobile1: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3',
   };
 
   const gapStyles = {
-    gapStyle1: 'gap-x-[14px] gap-y-[40px] md:gap-x-[20px] md:gap-y-[80px]', // BEST PICK, 토마토들 추천활동, 토마토 Pick
-    gapStyle2: 'gap-x-[14px] gap-y-[32px] md:gap-x-[20px] md:gap-y-[64px]', // 대외활동, 공모전
-    gapStyle3: 'gap-x-[0px] gap-y-[16px] md:gap-x-[30px] md:gap-y-[80px]', // 토마토 Tip
+    gapStyle1: 'gap-x-4 gap-y-8 md:gap-x-8 md:gap-y-12', // BEST PICK, 토마토들 추천활동, 토마토 Pick
+    gapStyle2: 'gap-x-6 gap-y-10 md:gap-x-10 md:gap-y-12', // 대외활동, 공모전
+    gapStyle3: 'gap-x-2 gap-y-6 md:gap-x-8 md:gap-y-10', // 토마토 Tip
   };
 
   const gridClass =

--- a/src/containers/home/BestPickGridView.tsx
+++ b/src/containers/home/BestPickGridView.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import GridView from "@/components/ui/grid/GridView";
+import { useEffect, useState } from "react";
+import HomeGridItem from "./HomeGridItem";
+
+async function FetchData(): Promise<ContestActivityDataProps []> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/activities_contests?select=*&order=view_count.desc&limit=8`, {
+    headers: {
+      'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+      'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}`,
+    },
+  });
+
+  if (!response.ok) {
+    console.error("데이터를 가져오는 중 오류 발생");
+    return [];
+  }
+
+  const data: ContestActivityDataProps[] = await response.json();
+  return data;
+}
+
+export default function BestPickGridView() {
+  const [activities, setActivities] = useState<ContestActivityDataProps []>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await FetchData();
+      setActivities(data);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div className="w-full h-full">
+      <GridView
+        items={activities}
+        GridItem={HomeGridItem}
+        columnStyle="web4mobile2"
+        gapStyle="gapStyle2"
+      />
+    </div>
+  );
+}

--- a/src/containers/home/ContestCardSlider.tsx
+++ b/src/containers/home/ContestCardSlider.tsx
@@ -3,38 +3,38 @@ import { useState, useEffect } from 'react';
 import { AiOutlineLeftCircle, AiOutlineRightCircle } from 'react-icons/ai';
 import Image from 'next/image';
 import Dday from '@/components/common/Dday';
+import GridView from '@/components/ui/grid/GridView';
+import HomeGridItem from './HomeGridItem';
 
-interface DdayProps {
-  type: 'active' | 'completed' | 'upcoming';
-  day?: string;
-  color?: 'red' | 'yellow' | 'green';
-}
+async function FetchData(): Promise<ContestActivityDataProps []> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/activities_contests`, {
+    headers: {
+      'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+      'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}`,
+    },
+  });
 
-interface CardProps {
-  title: string;
-  period: string;
-  imageUrl: string;
-  dDay: DdayProps;
-}
+  if (!response.ok) {
+    console.error("데이터를 가져오는 중 오류 발생");
+    return [];
+  }
 
-function Card({ title, period, imageUrl, dDay }: CardProps) {
-  return (
-    <div className="m-3 overflow-hidden rounded-lg bg-white shadow-lg">
-      <div className="relative h-48 w-full">
-        <Image src={imageUrl} alt={title} fill objectFit="cover" />
-      </div>
-      <div className="p-4">
-        <h3 className="my-2 text-base font-bold">{title}</h3>
-        <div className="flex items-center">
-          <Dday type={dDay.type} color={dDay.color} day={dDay.day} />
-          <span className="ml-2 text-sm text-gray-600">{period}</span>
-        </div>
-      </div>
-    </div>
-  );
+  const data: ContestActivityDataProps[] = await response.json();
+  return data;
 }
 
 function ContestCardSlider() {
+  const [activities, setActivities] = useState<ContestActivityDataProps []>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await FetchData();
+      setActivities(data);
+    };
+
+    fetchData();
+  }, []);
+
   const [itemsPerPage, setItemsPerPage] = useState(3);
   const [currentPage, setCurrentPage] = useState(0);
 
@@ -58,72 +58,9 @@ function ContestCardSlider() {
     };
   }, []);
 
-  const cards: CardProps[] = [
-    {
-      title: '2024 영광 방문의 해 맞이 숏-폼 공모전',
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Contest1.png',
-      dDay: {
-        type: 'active',
-        day: '20',
-        color: 'red',
-      },
-    },
-    {
-      title: "EBS 온라인클래스 교육콘텐츠 공모전, '온라인 클래스'",
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Contest2.png',
-      dDay: {
-        type: 'active',
-        day: '10',
-        color: 'yellow',
-      },
-    },
-    {
-      title: '한국체육산업개발(주) 홍보 웹툰 공모전',
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Main_Poster2.png',
-      dDay: {
-        type: 'active',
-        day: '5',
-        color: 'green',
-      },
-    },
-    {
-      title: "EBS 온라인클래스 교육콘텐츠 공모전, '온라인 클래스'",
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Contest2.png',
-      dDay: {
-        type: 'active',
-        day: '10',
-        color: 'yellow',
-      },
-    },
-    {
-      title: '한국체육산업개발(주) 홍보 웹툰 공모전',
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Main_Poster2.png',
-      dDay: {
-        type: 'active',
-        day: '5',
-        color: 'green',
-      },
-    },
-    {
-      title: '2024 영광 방문의 해 맞이 숏-폼 공모전',
-      period: '24.09.02 ~ 24.09.15',
-      imageUrl: '/assets/homePage/Contest1.png',
-      dDay: {
-        type: 'active',
-        day: '20',
-        color: 'red',
-      },
-    },
-  ];
+  const totalPages = Math.ceil(activities.length / itemsPerPage);
 
-  const totalPages = Math.ceil(cards.length / itemsPerPage);
-
-  const currentItems = cards.slice(
+  const currentItems = activities.slice(
     currentPage * itemsPerPage,
     (currentPage + 1) * itemsPerPage
   );
@@ -142,16 +79,13 @@ function ContestCardSlider() {
 
   return (
     <section className="flex flex-col items-center gap-4 p-4">
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-        {currentItems.map((card, index) => (
-          <Card
-            key={index}
-            title={card.title}
-            period={card.period}
-            imageUrl={card.imageUrl}
-            dDay={card.dDay}
-          />
-        ))}
+      <div className="w-full h-full">
+        <GridView
+          items={activities}
+          GridItem={HomeGridItem}
+          columnStyle="web4mobile2"
+          gapStyle="gapStyle2"
+        />
       </div>
 
       <div className="mt-6 flex items-center justify-center gap-10">

--- a/src/containers/home/ContestCardSlider.tsx
+++ b/src/containers/home/ContestCardSlider.tsx
@@ -1,8 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { AiOutlineLeftCircle, AiOutlineRightCircle } from 'react-icons/ai';
-import Image from 'next/image';
-import Dday from '@/components/common/Dday';
 import GridView from '@/components/ui/grid/GridView';
 import HomeGridItem from './HomeGridItem';
 

--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -8,22 +8,9 @@ import { AiOutlineRight } from 'react-icons/ai';
 import Link from 'next/link';
 import HomeGridItem from './HomeGridItem';
 import GridView from '@/components/ui/grid/GridView';
+import BestPickGridView from './BestPickGridView';
 
 export default function Home() {
-  const dummyActivities: ActivityContestDetailsProps[] = Array.from(
-    { length: 8 },
-    (_, i) => ({
-      imageUrl: '/assets/test_image.png',
-      title: `활동 타이틀 ${i + 1}`,
-      organization: `주최 기관 ${i + 1}`,
-      dDay: `${Math.floor(Math.random() * 30)}`, // 0 ~ 29일 랜덤 마감일
-      receptionPeriod: `10월 ${Math.floor(Math.random() * 10) + 1}일(월) ~ 10월 ${Math.floor(Math.random() * 20) + 10}일(금)`,
-      category: i % 2 === 0 ? '대외활동' : '공모전', // '교육・강연' 제거, 대외활동과 공모전만 사용
-      viewCount: `${Math.floor(Math.random() * 5000) + 1000}`, // 1000 ~ 6000 랜덤 조회수 (string으로 변환)
-      detailUrl: `/activities/${i + 1}`, // detailUrl 추가
-    })
-  );
-
   return (
     <>
       {/* 메인 공고 컴포넌트 */}
@@ -35,12 +22,13 @@ export default function Home() {
         <p className="ml-8 mt-20 font-recipe text-[28px] font-normal leading-[48px] text-point-red-500 md:text-[32px]">
           BEST PICK
         </p>
-        {/* GridView 컴포넌트를 사용해서 변경해주세요 */}
-        {/* <PaginationForHome contents={dummyActivities} /> */}
+        <section className="mx-8 my-5 flex flex-col">
+          <BestPickGridView />
+        </section>
       </section>
 
       {/* 토마토들 추천 활동 */}
-      <section className="ml-8 flex items-center">
+      <section className="ml-8 mt-20 flex items-center">
         <p className="font-recipe text-[28px] font-normal leading-[48px] md:text-[32px]">
           토마토들 <span className="text-point-red-500">추천 활동</span>
         </p>
@@ -52,17 +40,17 @@ export default function Home() {
           className="ml-2"
         />
       </section>
-      <section className="mx-8 my-5 mb-20 flex flex-col">
-        <GridView
+      <section className="mx-8 my-5 flex flex-col">
+        {/* <GridView
           items={dummyActivities}
           GridItem={HomeGridItem}
           columnStyle="web4mobile2"
           gapStyle="gapStyle1"
-        />
+        /> */}
       </section>
 
       {/* 공모전 */}
-      <section className="mt-10">
+      <section className="mt-20">
         <div className="flex flex-row justify-between">
           <p className="ml-8 font-recipe text-[28px] font-normal leading-[48px] md:text-[32px]">
             공모전
@@ -79,7 +67,7 @@ export default function Home() {
       </section>
 
       {/* 대외활동 */}
-      <section className="mt-10">
+      <section className="mt-20">
         <div className="flex flex-row justify-between">
           <p className="ml-8 font-recipe text-[28px] font-normal leading-[48px] md:text-[32px]">
             대외활동
@@ -96,7 +84,7 @@ export default function Home() {
       </section>
 
       {/* 매거진 */}
-      <section className="ml-8 mt-10">
+      <section className="ml-8 mt-20">
         <div className="flex flex-row justify-between">
           <p className="font-recipe text-[28px] font-normal leading-[48px] md:text-[32px]">
             매거진
@@ -109,7 +97,7 @@ export default function Home() {
             <AiOutlineRight />
           </Link>
         </div>
-        <TomatoTips pageSize={3} showPagination={false} />
+        매거진 컴포넌트 넣기
       </section>
     </>
   );

--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -3,12 +3,10 @@ import MainSlider from '@/containers/home/MainSlider';
 import Image from 'next/image';
 import ContestCardSlider from '@/containers/home/ContestCardSlider';
 import ActivityCardSlider from '@/containers/home/ActivityCardSlider';
-import TomatoTips from '../magazine/TomatoTips';
 import { AiOutlineRight } from 'react-icons/ai';
 import Link from 'next/link';
-import HomeGridItem from './HomeGridItem';
-import GridView from '@/components/ui/grid/GridView';
 import BestPickGridView from './BestPickGridView';
+import RecoActivityGridView from './RecoActivityGridView';
 
 export default function Home() {
   return (
@@ -41,12 +39,7 @@ export default function Home() {
         />
       </section>
       <section className="mx-8 my-5 flex flex-col">
-        {/* <GridView
-          items={dummyActivities}
-          GridItem={HomeGridItem}
-          columnStyle="web4mobile2"
-          gapStyle="gapStyle1"
-        /> */}
+        <RecoActivityGridView />
       </section>
 
       {/* 공모전 */}

--- a/src/containers/home/HomeGridItem.tsx
+++ b/src/containers/home/HomeGridItem.tsx
@@ -3,56 +3,54 @@ import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import Link from 'next/link';
 
-// 접수 기간의 마감 날짜만 추출하는 함수
-const extractEndDate = (receptionPeriod: string) => {
-  const dates = receptionPeriod.split('~');
-  return dates[1]?.trim() || receptionPeriod; // 마감 날짜가 없으면 전체 기간 반환
-};
-
-export default function HomeGridItem({ item }: ActivityContestListProps) {
-  const { imageUrl, title, dDay, receptionPeriod, category, detailUrl } = item;
+export default function HomeGridItem({ item }: ContestActivityListProps) {
+  const { id, title, d_day, start_date, end_date, view_count, main_category, thumbnail_url, homepage_url } = item;
+  const en_main_category = main_category === 'contest' ? 'contest' : 'activity';
 
   return (
-    <Link href={detailUrl} className="relative block justify-self-start">
+    <Link 
+      href={`${en_main_category}/${id}`} 
+      className="relative block justify-self-start"
+    >
       {/* 모바일 이미지 */}
-      <div className="block sm:hidden">
+      <div className="block sm:hidden mx-4 my-4">
         <Image
-          src={imageUrl}
+          src={thumbnail_url}
           alt={title}
           width={152}
           height={200}
-          className="rounded-[20px] border border-sub-gray-100"
+          className="rounded-[20px] border border-sub-gray-100 h-[200px] w-full object-cover"
         />
       </div>
 
       {/* 웹 이미지 */}
-      <div className="hidden sm:block">
+      <div className="hidden sm:block mb-4">
         <Image
-          src={imageUrl}
+          src={thumbnail_url}
           alt={title}
           width={300}
           height={360}
-          className="rounded-[20px] border border-sub-gray-100"
+          className="rounded-[20px] border border-sub-gray-100 h-[360px] object-cover"
         />
       </div>
 
       {/* 카테고리 */}
-      <div className="absolute right-2 top-2 rounded-full bg-sub-gray-500 px-2 py-[2px] text-xs font-normal text-white md:right-3 md:top-3 md:px-3 md:py-1 md:text-xl md:font-medium">
-        {category}
+      <div className="absolute right-2 top-2 rounded-full bg-sub-gray-500 px-2 py-[2px] text-xs font-normal text-white md:right-3 md:top-3 md:px-3 md:py-1 md:text-lg md:font-medium">
+        {main_category}
       </div>
 
       <div className="mt-2 md:mt-4">
         {/* 제목 */}
-        <h2 className="line-clamp-2 h-12 text-base font-semibold md:h-[78px] md:text-xl md:font-semibold">
+        <h2 className="line-clamp-0.5 h-12 mb-2 text-sm font-semibold md:h-[78px] md:text-base md:font-semibold lg:text-lg">
           {title}
         </h2>
 
         {/* D-Day 및 접수 기간 */}
         <div className="flex items-center gap-1.5">
-          <Dday type="active" day={dDay} color="red" />
-          <p className="md:text-md text-xs font-normal text-sub-gray-300 sm:text-sm md:font-medium lg:text-base xl:text-base">
-            <span className="inline sm:hidden">{`~ ${extractEndDate(receptionPeriod)}`}</span>
-            <span className="hidden sm:inline">{receptionPeriod}</span>
+          <Dday type="active" day={d_day} color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'} />
+          <p className="md:text-md text-xs font-normal text-sub-gray-300 sm:text-sm md:font-medium md:text-sm lg:text-base xl:text-base">
+            <span className="inline sm:hidden">{`~ ${end_date}`}</span>
+            <span className="hidden sm:inline">{`${start_date} ~ ${end_date}`}</span>
           </p>
         </div>
       </div>

--- a/src/containers/home/RecoActivityGridView.tsx
+++ b/src/containers/home/RecoActivityGridView.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from "react";
 import HomeGridItem from "./HomeGridItem";
 
 async function FetchData(): Promise<ContestActivityDataProps []> {
-  // 조회수(view_count)가 높은 순으로 정렬 후 8개만 가져오기
-  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/activities_contests?select=*&order=view_count.desc&limit=8`, {
+  // D-day 오름차순으로 정렬 후 8개만 가져오기
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/activities_contests?select=*&d_day=gt.0&order=d_day.asc&limit=8`, {
     headers: {
       'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
       'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}`,
@@ -22,7 +22,7 @@ async function FetchData(): Promise<ContestActivityDataProps []> {
   return data;
 }
 
-export default function BestPickGridView() {
+export default function RecoActivityGridView() {
   const [activities, setActivities] = useState<ContestActivityDataProps []>([]);
 
   useEffect(() => {

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -10,6 +10,9 @@ type ActivityContestDetailsProps = {
   detailUrl: string;
 };
 
+type ActivityContestListProps = {
+  item: ActivityContestDetailProps;
+};
 // 전체 데이터 타입
 type ActivityContestDataType = {
   id: number;
@@ -22,7 +25,7 @@ type ActivityContestDataType = {
   award_info: string; // text, nullable
   dominant_color: string; // char(7) (e.g., "#FFFFFF"), nullable
   description: string; // text, nullable
-  main_category: '공모전' | '대외활동'; // varchar, limited to values "공모전" or "대외활동"
+  main_category: 'activity' | 'contest' // varchar, limited to values "공모전" or "대외활동"
   homepage_url: string; // text, nullable
   registration_date: string; // date in ISO format ("YYYY-MM-DD")
   d_day: number; // 디데이 (숫자)
@@ -39,7 +42,19 @@ type ActivityContestDataType = {
   target?: string | null;
   organizer?: string | null;
 };
+// 공모전, 대외활동 
+type ContestActivityDataProps = {
+  id: number;
+  title: string;
+  d_day: number;
+  start_date: string;
+  end_date: string;
+  view_count: number;
+  main_category: 'activity' | 'contest';
+  thumbnail_url: string;
+  homepage_url: string;
+};
 
-type ActivityContestListProps = {
-  item: ActivityContestDetailProps;
+type ContestActivityListProps = {
+  item: ContestActivityDataProps;
 };


### PR DESCRIPTION
## 변경 사항 설명
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요. -->
- 홈 화면만의 레이아웃 설정을 통한 깔끔한 디자인 구현. ➡️ 컴포넌트 레이아웃과 홈 화면 레이아웃을 구분하여 적용.
- 크롤링 코드와 컴포넌트들을 연결함으로써, 실제 데이터를 사용하여 구현. ➡️ BEST PICK / 토마토들 추천 활동에 적용. 나머지는 진행 중.
- 컴포넌트에서 사용하는 타입 구조 추출.

## 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. (예: #123) -->
#38 

## 변경 유형
- [X] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [X] 리팩토링 (기능 변경 없음)

## 체크리스트
<!--PR 체크리스트에 어떤 내용이 들어가면 좋을지 논의해 봅시다.-->
- [X] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [X] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
<!-- PR에 대한 추가 정보나 스크린샷이 있다면 여기에 추가해주세요. -->
<img width="1328" alt="Screenshot 2024-10-29 at 22 48 40" src="https://github.com/user-attachments/assets/87defc02-2e59-47f7-b8fc-26d46911e1f1">

BEST PICK은 조회수를 기준으로 내림차순 정렬하였습니다.
<br/>

<img width="1328" alt="Screenshot 2024-10-29 at 22 48 58" src="https://github.com/user-attachments/assets/cef83981-1a38-4c91-b078-968fb77a7685">

토마토들 추천활동은 D-day 값을 기준으로 0 이상이도록 필터링하고, 오름차순으로 정렬하였습니다. 