### PR TITLE
Feat: 공모전 및 대외활동 상세 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6055,6 +6055,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
+      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/activity/[id]/page.tsx
+++ b/src/app/activity/[id]/page.tsx
@@ -1,3 +1,42 @@
-export default function Page() {
-  return <>상세 페이지입니다</>;
+import ActivityDetail from '@/containers/activity/ActivityDetail';
+import { fetchActivityContestDetailWith } from '@/lib/fetchActivityContestDetailWith';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function generateStaticParams() {
+  const { data: posts, error } = await supabase
+    .from('activities_contests')
+    .select('id')
+    .neq('id', null);
+
+  if (error) {
+    console.error('Error fetching IDs:', error);
+    return [];
+  }
+
+  return posts.map((post) => ({
+    id: post.id.toString(),
+  }));
+}
+
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export default async function Page({ params }: PageProps) {
+  const id = Number(params.id);
+  const mainCategory = '대외활동';
+
+  const { data: activityDetail, error } = await fetchActivityContestDetailWith(
+    id,
+    mainCategory
+  );
+
+  if (error || !activityDetail) {
+    return <div>데이터 로딩 중 에러 발생</div>;
+  }
+
+  // 개별 필드를 직접 전달
+  return <ActivityDetail {...activityDetail} />;
 }

--- a/src/app/contest/[id]/page.tsx
+++ b/src/app/contest/[id]/page.tsx
@@ -1,3 +1,44 @@
-export default function Page() {
-  return <>상세 페이지입니다</>;
+import ContestDetail from '@/containers/contest/ContestDetail';
+import { fetchActivityContestDetailWith } from '@/lib/fetchActivityContestDetailWith';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function generateStaticParams() {
+  const { data: posts, error } = await supabase
+    .from('activities_contests')
+    .select('id')
+    .neq('id', null);
+
+  if (error) {
+    console.error('Error fetching IDs:', error);
+    return [];
+  }
+
+  return posts.map((post) => ({
+    id: post.id.toString(),
+  }));
+}
+
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export default async function Page({ params }: PageProps) {
+  const id = Number(params.id);
+  const mainCategory = '공모전';
+
+  const { data: contestDetail, error } = await fetchActivityContestDetailWith(
+    id,
+    mainCategory
+  );
+
+  if (error || !contestDetail) {
+    return <div>데이터 로딩 중 에러 발생</div>;
+  }
+
+  console.log(contestDetail);
+
+  // 개별 필드를 직접 전달
+  return <ContestDetail {...contestDetail} />;
 }

--- a/src/components/common/ActivityContestDescription.tsx
+++ b/src/components/common/ActivityContestDescription.tsx
@@ -1,0 +1,18 @@
+type ActivityContestDescriptionProps = {
+  description: string;
+};
+
+export default function ActivityContestDescription({
+  description,
+}: ActivityContestDescriptionProps) {
+  return (
+    <section className="px-20">
+      {description.split('\n').map((line, index) => (
+        <div key={index}>
+          <span className="block">{line}</span>
+          <br />
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/components/common/ActivityContestDetailTab.tsx
+++ b/src/components/common/ActivityContestDetailTab.tsx
@@ -10,14 +10,14 @@ export default function ActivityContestDetailTab({
   const tabs = ['상세내용', '토마토 TIP', '수상작 갤러리'];
 
   return (
-    <ul className="mb-16 mt-40 flex items-center justify-center border-b-[1px] border-sub-gray-100">
+    <ul className="mb-16 mt-16 flex items-center justify-center border-b-[1px] border-sub-gray-100 md:mt-40">
       {tabs.map((tab) => (
         <li
           key={tab}
           onClick={() => setActiveTab(tab)}
-          className={`flex-1 cursor-pointer pb-[18px] text-center text-2xl font-semibold ${
+          className={`flex-1 cursor-pointer pb-[18px] text-center text-base font-medium md:text-2xl md:font-semibold ${
             activeTab === tab
-              ? 'border-b-4 border-point-red-500 text-point-red-500'
+              ? 'border-b-2 border-point-red-500 text-point-red-500 md:border-b-4'
               : 'text-sub-gray-200'
           }`}
         >

--- a/src/components/common/ActivityContestDetailTab.tsx
+++ b/src/components/common/ActivityContestDetailTab.tsx
@@ -1,0 +1,29 @@
+type ActivityContestDetailTabProps = {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+};
+
+export default function ActivityContestDetailTab({
+  activeTab,
+  setActiveTab,
+}: ActivityContestDetailTabProps) {
+  const tabs = ['상세내용', '토마토 TIP', '수상작 갤러리'];
+
+  return (
+    <ul className="mb-16 mt-40 flex items-center justify-center border-b-[1px] border-sub-gray-100">
+      {tabs.map((tab) => (
+        <li
+          key={tab}
+          onClick={() => setActiveTab(tab)}
+          className={`flex-1 cursor-pointer pb-[18px] text-center text-2xl font-semibold ${
+            activeTab === tab
+              ? 'border-b-4 border-point-red-500 text-point-red-500'
+              : 'text-sub-gray-200'
+          }`}
+        >
+          {tab}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/common/CategoryHeader.tsx
+++ b/src/components/common/CategoryHeader.tsx
@@ -15,6 +15,7 @@ export default function CategoryHeader() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const isMagazine = /^\/magazine/.test(pathname);
+  const isDetailPage = /^\/(activity|contest)\/\d+$/.test(pathname); // 상세 페이지 여부 확인
 
   // 페이지 제목과 탭 설정
   const pageTitle = (() => {
@@ -131,7 +132,7 @@ export default function CategoryHeader() {
         isMagazine={isMagazine}
       />
 
-      {filters && !isMagazine && (
+      {filters && !isMagazine && !isDetailPage && (
         <FilterPanel
           filters={filters[activeTab as keyof typeof filters] || []}
           selectedFilters={selectedFilters}

--- a/src/components/common/FilterPanel.tsx
+++ b/src/components/common/FilterPanel.tsx
@@ -36,7 +36,7 @@ export default function FilterPanel({
             />
           ))
         ) : (
-          <div>해당 카테고리는 필터가 없습니다.</div>
+          <div></div>
         )}
       </div>
 

--- a/src/components/common/SortPanel.tsx
+++ b/src/components/common/SortPanel.tsx
@@ -25,7 +25,7 @@ export default function SortPanel({
                 : 'text-sub-gray-200'
             } ${
               index !== 0
-                ? 'before:absolute before:-left-6 before:top-1/2 before:h-[20px] before:w-[1px] before:-translate-y-1/2 before:transform before:bg-sub-gray-100'
+                ? 'before:absolute before:-left-2 before:top-1/2 before:h-[20px] before:w-[1px] before:-translate-y-1/2 before:transform before:bg-sub-gray-100 md:before:-left-6'
                 : ''
             }`}
             onClick={() => onSortChange(option)}
@@ -46,6 +46,13 @@ export default function SortPanel({
           className="ml-2 hidden md:block"
           width={16.93}
           height={17.5}
+        />
+        <Image
+          src="/assets/common/PC_reset.svg"
+          alt="reset icon"
+          className="ml-2 block md:hidden"
+          width={9.67}
+          height={10}
         />
       </button>
     </div>

--- a/src/containers/activity/ActivityDetail.tsx
+++ b/src/containers/activity/ActivityDetail.tsx
@@ -1,43 +1,140 @@
-// import Image from 'next/image';
-// import Dday from '@/components/common/Dday';
+'use client';
 
-// export default function ActivityDetail({item}: ) {
-//   return (
-//     <section>
-//       <div>
-//         <div>
-//           <Image src={} alt="" width={} height={} className="block sm:hidden" />
-//           <Image src={} alt="" width={} height={} className="hidden sm:block" />
-//         </div>
-//         <div>
-//           <Dday type="" day="" color="" />
-//           <h2></h2>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">등록일: </span>
-//             <span>조회 회</span>
-//           </div>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">공모 분야</span>
-//             <span></span>
-//           </div>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">공모 기간</span>
-//             <span></span>
-//           </div>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">주최 기관</span>
-//             <span></span>
-//           </div>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">참여 대상</span>
-//             <span></span>
-//           </div>
-//           <div>
-//             <span className="pr-[30px] md:pr-[50px]">이지</span>
-//             <span></span>
-//           </div>
-//         </div>
-//       </div>
-//     </section>
-//   );
-// }
+import Image from 'next/image';
+import Dday from '@/components/common/Dday';
+import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
+import ActivityContestDescription from '@/components/common/ActivityContestDescription';
+import { useState } from 'react';
+
+type ActivityContestDetailProps = {
+  thumbnail_url: string;
+  title: string;
+  registration_date: string;
+  view_count: number;
+  start_date: string;
+  end_date: string;
+  company: string;
+  homepage_url: string;
+  d_day: number;
+  description: string;
+  department?: string;
+  target?: string;
+  field?: string;
+  duration?: string;
+};
+
+export default function ActivityDetail({
+  thumbnail_url,
+  title,
+  registration_date,
+  view_count,
+  start_date,
+  end_date,
+  company,
+  homepage_url,
+  d_day,
+  description,
+  field,
+  duration,
+}: ActivityContestDetailProps) {
+  const [activeTab, setActiveTab] = useState('상세내용');
+
+  const details = [
+    { label: '참여 분야', value: field },
+    { label: '공모 기간', value: `${start_date} ~ ${end_date}` },
+    { label: '주최 기관', value: company },
+    { label: '활동 기간', value: duration },
+    {
+      label: '홈페이지',
+      value: (
+        <a
+          href={homepage_url}
+          className="text-[14px] font-semibold text-sub-gray-500 underline md:text-[24px]"
+        >
+          캠퍼스픽
+        </a>
+      ),
+    },
+  ];
+
+  const ThumbnailImage = ({
+    url,
+    title,
+    isMobile,
+  }: {
+    url: string;
+    title: string;
+    isMobile: boolean;
+  }) => (
+    <div
+      className={`relative flex-1 overflow-hidden ${
+        isMobile ? 'sm:hidden' : 'hidden sm:block'
+      }`}
+      style={{
+        width: isMobile ? 318 : 495,
+        height: isMobile ? 449 : 698,
+      }}
+    >
+      <Image
+        src={url}
+        alt={title}
+        width={isMobile ? 318 : 495}
+        height={isMobile ? 449 : 698}
+        className="object-cover"
+      />
+    </div>
+  );
+
+  return (
+    <section className="px-7 md:px-[90px]">
+      <div className="flex flex-col items-center justify-around gap-[43px] md:flex-row md:gap-[106px]">
+        <ThumbnailImage url={thumbnail_url} title={title} isMobile={true} />
+        <ThumbnailImage url={thumbnail_url} title={title} isMobile={false} />
+
+        <div className="flex-1">
+          <Dday type="active" day={d_day} color="red" />
+          <h2 className="mb-2 mt-3 break-all text-2xl font-bold leading-normal text-sub-gray-500 md:text-5xl">
+            {title}
+          </h2>
+          <div className="mb-8 flex gap-2 md:mb-14 md:gap-4">
+            <span className="text-sm font-medium text-sub-gray-300 md:text-xl">
+              등록일: {registration_date}
+            </span>
+            <span className="relative mx-2 text-sub-gray-300 after:absolute after:left-0 after:top-1/2 after:h-4 after:w-[1px] after:-translate-y-1/2 after:bg-sub-gray-300" />
+            <span className="text-sm font-medium text-sub-gray-300 md:text-xl">
+              조회 {view_count}회
+            </span>
+          </div>
+          <div className="flex flex-col justify-center">
+            {details.map(({ label, value }, index) => (
+              <div
+                key={label}
+                className={`flex gap-[30px] border-sub-gray-100 py-5 md:gap-[50px] ${
+                  index === details.length - 1
+                    ? 'border-y-[1px]'
+                    : 'border-t-[1px]'
+                }`}
+              >
+                <span className="text-[16px] font-semibold text-sub-gray-500 md:text-[24px]">
+                  {label}:
+                </span>
+                <span className="text-[14px] font-normal text-sub-gray-500 md:text-[24px]">
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <ActivityContestDetailTab
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+      />
+      {activeTab === '상세내용' && (
+        <ActivityContestDescription description={description} />
+      )}
+      {activeTab === '토마토 TIP' && <div />} {/* 빈 컴포넌트 */}
+      {activeTab === '수상작 갤러리' && <div />} {/* 빈 컴포넌트 */}
+    </section>
+  );
+}

--- a/src/containers/contest/ContestDetail.tsx
+++ b/src/containers/contest/ContestDetail.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import Image from 'next/image';
+import Dday from '@/components/common/Dday';
+import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
+import ActivityContestDescription from '@/components/common/ActivityContestDescription';
+import { useState } from 'react';
+
+type ActivityContestDetailProps = {
+  thumbnail_url: string;
+  title: string;
+  registration_date: string;
+  view_count: number;
+  start_date: string;
+  end_date: string;
+  company: string;
+  homepage_url: string;
+  d_day: number;
+  description: string;
+  department?: string;
+  target?: string;
+  field?: string;
+  duration?: string;
+};
+
+export default function ContestDetail({
+  thumbnail_url,
+  title,
+  registration_date,
+  view_count,
+  start_date,
+  end_date,
+  company,
+  homepage_url,
+  d_day,
+  description,
+  department,
+  target,
+}: ActivityContestDetailProps) {
+  const [activeTab, setActiveTab] = useState('상세내용');
+
+  const details = [
+    { label: '공모 분야', value: department },
+    { label: '공모 기간', value: `${start_date} ~ ${end_date}` },
+    { label: '주최 기관', value: company },
+    { label: '참여 대상', value: target },
+    {
+      label: '홈페이지',
+      value: (
+        <a
+          href={homepage_url}
+          className="text-[14px] font-semibold text-sub-gray-500 underline md:text-[24px]"
+        >
+          캠퍼스픽
+        </a>
+      ),
+    },
+  ];
+
+  const ThumbnailImage = ({
+    url,
+    title,
+    isMobile,
+  }: {
+    url: string;
+    title: string;
+    isMobile: boolean;
+  }) => (
+    <div
+      className={`relative flex-1 overflow-hidden ${
+        isMobile ? 'sm:hidden' : 'hidden sm:block'
+      }`}
+      style={{
+        width: isMobile ? 318 : 495,
+        height: isMobile ? 449 : 698,
+      }}
+    >
+      <Image
+        src={url}
+        alt={title}
+        width={isMobile ? 318 : 495}
+        height={isMobile ? 449 : 698}
+        className="object-cover"
+      />
+    </div>
+  );
+
+  return (
+    <section className="px-7 md:px-[90px]">
+      <div className="flex flex-col items-center justify-around gap-[43px] md:flex-row md:gap-[106px]">
+        <ThumbnailImage url={thumbnail_url} title={title} isMobile={true} />
+        <ThumbnailImage url={thumbnail_url} title={title} isMobile={false} />
+
+        <div className="flex-1">
+          <Dday type="active" day={d_day} color="red" />
+          <h2 className="mb-2 mt-3 break-all text-2xl font-bold leading-normal text-sub-gray-500 md:text-5xl">
+            {title}
+          </h2>
+          <div className="mb-8 flex gap-2 md:mb-14 md:gap-4">
+            <span className="text-sm font-medium text-sub-gray-300 md:text-xl">
+              등록일: {registration_date}
+            </span>
+            <span className="relative mx-2 text-sub-gray-300 after:absolute after:left-0 after:top-1/2 after:h-4 after:w-[1px] after:-translate-y-1/2 after:bg-sub-gray-300" />
+            <span className="text-sm font-medium text-sub-gray-300 md:text-xl">
+              조회 {view_count}회
+            </span>
+          </div>
+          <div className="flex flex-col justify-center">
+            {details.map(({ label, value }, index) => (
+              <div
+                key={label}
+                className={`flex gap-[30px] border-sub-gray-100 py-5 md:gap-[50px] ${
+                  index === details.length - 1
+                    ? 'border-y-[1px]'
+                    : 'border-t-[1px]'
+                }`}
+              >
+                <span className="text-[16px] font-semibold text-sub-gray-500 md:text-[24px]">
+                  {label}:
+                </span>
+                <span className="text-[14px] font-normal text-sub-gray-500 md:text-[24px]">
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <ActivityContestDetailTab
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+      />
+      {activeTab === '상세내용' && (
+        <ActivityContestDescription description={description} />
+      )}
+      {activeTab === '토마토 TIP' && <div />} {/* 빈 컴포넌트 */}
+      {activeTab === '수상작 갤러리' && <div />} {/* 빈 컴포넌트 */}
+    </section>
+  );
+}

--- a/src/lib/fetchActivityContestDetailWith.ts
+++ b/src/lib/fetchActivityContestDetailWith.ts
@@ -1,0 +1,54 @@
+import { supabase } from './supabaseClient';
+import { PostgrestError } from '@supabase/supabase-js';
+
+type ActivityContestDetail = {
+  thumbnail_url: string;
+  title: string;
+  registration_date: string;
+  view_count: number;
+  start_date: string;
+  end_date: string;
+  company: string;
+  homepage_url: string;
+  d_day: number;
+  description: string;
+  department?: string; // 공모전일 경우 추가되는 필드
+  target?: string; // 공모전일 경우 추가되는 필드
+  field?: string; // 대외활동일 경우 추가되는 필드
+  duration?: string; // 대외활동일 경우 추가되는 필드
+};
+
+export const fetchActivityContestDetailWith = async (
+  id: number,
+  mainCategory: string
+): Promise<{
+  data: ActivityContestDetail | null;
+  error: PostgrestError | null;
+}> => {
+  try {
+    let selectFields =
+      'thumbnail_url, title, registration_date, view_count, start_date, end_date, company, homepage_url, d_day, description';
+
+    if (mainCategory === '공모전') {
+      selectFields += ', department, target';
+    } else if (mainCategory === '대외활동') {
+      selectFields += ', field, duration';
+    }
+
+    const { data, error } = await supabase
+      .from('activities_contests')
+      .select(selectFields)
+      .eq('id', id)
+      .single();
+
+    if (error || !data) {
+      return { data: null, error };
+    }
+
+    // data를 unknown으로 먼저 변환 후 ActivityContestDetail로 캐스팅
+    return { data: data as unknown as ActivityContestDetail, error: null };
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    return { data: null, error: error as PostgrestError };
+  }
+};


### PR DESCRIPTION
## 변경 사항 설명
리팩토링을 제외하고 구현 관련해서 드디어 제 마지막 PR입니다!
이번 PR에서는 공모전 및 대외활동의 상세 페이지를 구현했습니다.

- 이제 공모전/대외활동 미리보기 아이템을 클릭할 경우 해당 공모전/대외활동 상세 페이지로 이동합니다.
- 공모전/대외활동 상세 페이지에서는 필터 및 정렬 옵션이 보이지 않습니다.

### `fetchActivityContestDetailWith`
```ts
import { supabase } from './supabaseClient';
import { PostgrestError } from '@supabase/supabase-js';

// 타입 생략
export const fetchActivityContestDetailWith = async (
  id: number,
  mainCategory: string
): Promise<{
  data: ActivityContestDetail | null;
  error: PostgrestError | null;
}> => {
  try {
    let selectFields =
      'thumbnail_url, title, registration_date, view_count, start_date, end_date, company, homepage_url, d_day, description';

    if (mainCategory === '공모전') {
      selectFields += ', department, target';
    } else if (mainCategory === '대외활동') {
      selectFields += ', field, duration';
    }

    const { data, error } = await supabase
      .from('activities_contests')
      .select(selectFields)
      .eq('id', id)
      .single();

    if (error || !data) {
      return { data: null, error };
    }

    // data를 unknown으로 먼저 변환 후 ActivityContestDetail로 캐스팅
    return { data: data as unknown as ActivityContestDetail, error: null };
  } catch (error) {
    console.error('Error fetching data:', error);
    return { data: null, error: error as PostgrestError };
  }
};
```

- 해당 함수를 사용하면 공모전/대외활동의 상세 페이지에서 필요한 정보를 가져올 수 있습니다.
- 파라미터로 받는 mainCategory가 무엇이냐에 따라 공모전과 대외활동에 필요한 column을 선택해서 가져오게 됩니다.
- 반환 타입의 경우 genericStringError라는 타입을 반환해야 한다고 하는데, 에러 처리랑 관련된 것 같지만 정확한 처리 방법을 모르겠어서 일단 unknown으로 변환한 뒤 ActivityContestDetail 타입으로 캐스팅했습니다.

## 관련 이슈
#61 

## 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 내용 변경
- [ ] 기타 (설명해주세요):

## 체크리스트
<!--PR 체크리스트에 어떤 내용이 들어가면 좋을지 논의해 봅시다.-->
- [ ] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [ ] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
<!-- PR에 대한 추가 정보나 스크린샷이 있다면 여기에 추가해주세요. -->
