### PR TITLE
Refactor: 발표 전 리팩토링

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -10,13 +10,9 @@ interface PageProps {
 }
 
 export default async function Page({ searchParams }: PageProps) {
-  // URL 파라미터에서 필터와 정렬 옵션 추출
   const filters = searchParams.filters?.split(',').filter(Boolean) || [];
   const sort = searchParams.sort || '관련도순';
 
-  console.log(filters, sort);
-
-  // 필터와 정렬 옵션을 API 호출에 전달
   const { data: activitiesContests, error } =
     await fetchActivityContestAbstractWith({
       filters,

--- a/src/app/contest/[id]/page.tsx
+++ b/src/app/contest/[id]/page.tsx
@@ -37,8 +37,6 @@ export default async function Page({ params }: PageProps) {
     return <div>데이터 로딩 중 에러 발생</div>;
   }
 
-  console.log(contestDetail);
-
   // 개별 필드를 직접 전달
   return <ContestDetail {...contestDetail} />;
 }

--- a/src/app/contest/page.tsx
+++ b/src/app/contest/page.tsx
@@ -14,8 +14,6 @@ export default async function Page({ searchParams }: PageProps) {
   const filters = searchParams.filters?.split(',').filter(Boolean) || [];
   const sort = searchParams.sort || '관련도순';
 
-  console.log(filters, sort);
-
   // 필터와 정렬 옵션을 API 호출에 전달
   const { data: activitiesContests, error } =
     await fetchActivityContestAbstractWith({

--- a/src/components/ui/navigation/NavItem.tsx
+++ b/src/components/ui/navigation/NavItem.tsx
@@ -1,16 +1,9 @@
 import Link from 'next/link';
 
-type navItemType = {
-  name: string;
-  route: string;
-  hasNewContent: boolean;
-};
-
 export default function NavItem({
   name,
   route,
   isActive,
-  hasNewContent,
 }: navItemType & { isActive: boolean }) {
   const baseClasses =
     'relative text-sm md:text-base lg:text-2xl font-medium lg:font-semibold box-border border-b-0 md:border-b-2';
@@ -25,7 +18,7 @@ export default function NavItem({
     <li className={finalClasses}>
       <Link href={route}>
         {name}
-        {hasNewContent && (
+        {isActive && (
           <span className="absolute -right-2 top-1 inline-block h-[5px] w-[5px] rounded-full bg-point-red-500"></span>
         )}
       </Link>

--- a/src/components/ui/navigation/Navigation.tsx
+++ b/src/components/ui/navigation/Navigation.tsx
@@ -7,16 +7,15 @@ import NavItem from './NavItem';
 type navItemType = {
   name: string;
   route: string;
-  hasNewContent: boolean; // 새로운 콘텐츠 여부
 };
 
 export default function Navigation() {
   const pathname = usePathname();
 
   const navItems: navItemType[] = [
-    { name: '매거진', route: '/magazine', hasNewContent: true },
-    { name: '공모전', route: '/contest', hasNewContent: false },
-    { name: '대외활동', route: '/activity', hasNewContent: false },
+    { name: '매거진', route: '/magazine' },
+    { name: '공모전', route: '/contest' },
+    { name: '대외활동', route: '/activity' },
   ];
 
   const containerClasses =

--- a/src/containers/activity/Activity.tsx
+++ b/src/containers/activity/Activity.tsx
@@ -10,14 +10,16 @@ export default function Activity({ activitiesContests }: ActivityProps) {
   return (
     <>
       <Suspense fallback={<div>로딩 중...</div>}>
-        <Pagination
-          contents={activitiesContests}
-          GridItem={ActivityContestItem}
-          webItemPerPage={16}
-          mobileItemPerPage={10}
-          columnStyle="web4mobile2"
-          gapStyle="gapStyle2"
-        />
+        <div className="px-7 md:px-[88px]">
+          <Pagination
+            contents={activitiesContests}
+            GridItem={ActivityContestItem}
+            webItemPerPage={16}
+            mobileItemPerPage={10}
+            columnStyle="web4mobile2"
+            gapStyle="gapStyle2"
+          />
+        </div>
       </Suspense>
     </>
   );

--- a/src/containers/activity/ActivityDetail.tsx
+++ b/src/containers/activity/ActivityDetail.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
 import ActivityContestDescription from '@/components/common/ActivityContestDescription';
+import { formatDate } from '@/utils/format';
 import { useState } from 'react';
 
 type ActivityContestDetailProps = {
@@ -38,10 +39,17 @@ export default function ActivityDetail({
   duration,
 }: ActivityContestDetailProps) {
   const [activeTab, setActiveTab] = useState('상세내용');
+  const [formatted_start_date, formatted_end_date] = [
+    formatDate(start_date),
+    formatDate(end_date),
+  ];
 
   const details = [
     { label: '참여 분야', value: field },
-    { label: '공모 기간', value: `${start_date} ~ ${end_date}` },
+    {
+      label: '공모 기간',
+      value: `${formatted_start_date} ~ ${formatted_end_date}`,
+    },
     { label: '주최 기관', value: company },
     { label: '활동 기간', value: duration },
     {

--- a/src/containers/contest/Contest.tsx
+++ b/src/containers/contest/Contest.tsx
@@ -10,14 +10,16 @@ export default function Contest({ activitiesContests }: ContestProps) {
   return (
     <>
       <Suspense fallback={<div>로딩 중...</div>}>
-        <Pagination
-          contents={activitiesContests}
-          GridItem={ActivityContestItem}
-          webItemPerPage={16}
-          mobileItemPerPage={10}
-          columnStyle="web4mobile2"
-          gapStyle="gapStyle2"
-        />
+        <div className="px-7 md:px-[88px]">
+          <Pagination
+            contents={activitiesContests}
+            GridItem={ActivityContestItem}
+            webItemPerPage={16}
+            mobileItemPerPage={10}
+            columnStyle="web4mobile2"
+            gapStyle="gapStyle2"
+          />
+        </div>
       </Suspense>
     </>
   );

--- a/src/containers/contest/ContestDetail.tsx
+++ b/src/containers/contest/ContestDetail.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
 import ActivityContestDescription from '@/components/common/ActivityContestDescription';
+import { formatDate } from '@/utils/format';
 import { useState } from 'react';
 
 type ActivityContestDetailProps = {
@@ -38,10 +39,17 @@ export default function ContestDetail({
   target,
 }: ActivityContestDetailProps) {
   const [activeTab, setActiveTab] = useState('상세내용');
+  const [formatted_start_date, formatted_end_date] = [
+    formatDate(start_date),
+    formatDate(end_date),
+  ];
 
   const details = [
     { label: '공모 분야', value: department },
-    { label: '공모 기간', value: `${start_date} ~ ${end_date}` },
+    {
+      label: '공모 기간',
+      value: `${formatted_start_date} ~ ${formatted_end_date}`,
+    },
     { label: '주최 기관', value: company },
     { label: '참여 대상', value: target },
     {
@@ -133,8 +141,8 @@ export default function ContestDetail({
       {activeTab === '상세내용' && (
         <ActivityContestDescription description={description} />
       )}
-      {activeTab === '토마토 TIP' && <div />} {/* 빈 컴포넌트 */}
-      {activeTab === '수상작 갤러리' && <div />} {/* 빈 컴포넌트 */}
+      {activeTab === '토마토 TIP' && <div />}
+      {activeTab === '수상작 갤러리' && <div />}
     </section>
   );
 }

--- a/src/lib/fetchActivityAbstractWith.ts
+++ b/src/lib/fetchActivityAbstractWith.ts
@@ -1,5 +1,41 @@
 import { supabase } from './supabaseClient';
 
+/**
+ * Fetches abstracts from the `activities_contests` table in Supabase with filters and sorting options.
+ *
+ * @async
+ * @function fetchActivityContestAbstractWith
+ * @param {Object} params - The parameters for fetching data.
+ * @param {string[]} [params.filters=[]] - List of filter values to apply on various columns.
+ *                                         Available columns are: `field`, `activity`, `host`, `duration`, `region`,
+ *                                         `department`, `prize_amount`, `prize_benefit`, `target`, `organizer`.
+ * @param {string} [params.sort='관련도순'] - The sorting order. Options include:
+ *                                          - `'관련도순'`: Sort by relevance (default).
+ *                                          - `'최신순'`: Sort by newest.
+ *                                          - `'조회순'`: Sort by view count.
+ *                                          - `'마감순'`: Sort by deadline (ascending).
+ * @param {string} params.mainCategory - The main category for filtering activities/contests.
+ *
+ * @returns {Promise<{data: Object[] | null, error: Error | null}>} A promise that resolves to an object containing:
+ *                                                                  - `data`: Array of fetched records or `null` if an error occurred.
+ *                                                                  - `error`: Error information or `null` if no error occurred.
+ *
+ * @throws Will throw an error if the Supabase query fails.
+ *
+ * @example
+ * // Fetch data with specific filters and sort by '최신순'
+ * const { data, error } = await fetchActivityContestAbstractWith({
+ *   filters: ['IT', '서울'],
+ *   sort: '최신순',
+ *   mainCategory: 'contest',
+ * });
+ *
+ * if (error) {
+ *   console.error('Error fetching data:', error);
+ * } else {
+ *   console.log('Fetched data:', data);
+ * }
+ */
 export async function fetchActivityContestAbstractWith({
   filters = [],
   sort = '관련도순',

--- a/src/lib/fetchActivityContestDetailWith.ts
+++ b/src/lib/fetchActivityContestDetailWith.ts
@@ -12,12 +12,39 @@ type ActivityContestDetail = {
   homepage_url: string;
   d_day: number;
   description: string;
-  department?: string; // 공모전일 경우 추가되는 필드
-  target?: string; // 공모전일 경우 추가되는 필드
-  field?: string; // 대외활동일 경우 추가되는 필드
-  duration?: string; // 대외활동일 경우 추가되는 필드
+  department?: string;
+  target?: string;
+  field?: string;
+  duration?: string;
 };
 
+/**
+ * Fetches detailed information for a specific activity or contest item from Supabase.
+ *
+ * @async
+ * @function fetchActivityContestDetailWith
+ * @param {number} id - The unique identifier of the activity or contest item.
+ * @param {string} mainCategory - The main category, which determines additional fields to include.
+ *                                - `'공모전'`: Includes `department` and `target` fields.
+ *                                - `'대외활동'`: Includes `field` and `duration` fields.
+ *
+ * @returns {Promise<{data: ActivityContestDetail | null, error: PostgrestError | null}>}
+ *          A promise that resolves to an object containing:
+ *          - `data`: The detailed information of the specified item or `null` if an error occurred.
+ *          - `error`: Supabase's `PostgrestError` object or `null` if no error occurred.
+ *
+ * @throws Will log an error if the data fetching fails.
+ *
+ * @example
+ * // Fetch the details of an activity with ID 1 and main category '대외활동'
+ * const { data, error } = await fetchActivityContestDetailWith(1, '대외활동');
+ *
+ * if (error) {
+ *   console.error('Error fetching detail:', error);
+ * } else {
+ *   console.log('Activity Contest Detail:', data);
+ * }
+ */
 export const fetchActivityContestDetailWith = async (
   id: number,
   mainCategory: string

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -5,3 +5,8 @@ type CategoryFilters = {
   활동기간: string[];
   지역: string[];
 };
+
+type navItemType = {
+  name: string;
+  route: string;
+};


### PR DESCRIPTION
## 변경 사항 설명
본 PR은 발표 전 @starcradle101 이 작업한 파트에 대한 마지막 PR입니다.
전반적인 CSS 관련 리팩토링을 진행했으며, 더 자세한 리팩토링에 대해서는 발표 종료 이후 계획을 세워 진행할 예정입니다.

### CSS 관련 변경사항
- 공모전 및 대외활동 페이지에서 `Pagination` 컴포넌트에 가로 패딩이 적용되도록 했습니다.
- 헤더에서 선택된 항목에 따라 데코레이터를 적용했습니다.

### 기타
- 불필요한 `console.log` 및 주석을 삭제했습니다.
- 공모전 및 대외활동 상세 페이지에서 날짜 형식을 피그마 디자인 시안에 맞게 적용했습니다.

## 관련 이슈
#68 

## 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [ ] 리팩토링 (기능 변경 없음)

## 체크리스트
- [ ] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [ ] 필요한 경우, 주석을 추가했습니다.

## 추가 정보

