### PR TITLE
Refactor: 페이지네이션 관련 리팩토링

### DIFF
--- a/src/app/activity/[id]/page.tsx
+++ b/src/app/activity/[id]/page.tsx
@@ -4,9 +4,8 @@ import { supabase } from '@/lib/supabaseClient';
 
 export async function generateStaticParams() {
   const { data: posts, error } = await supabase
-    .from('activities_contests')
-    .select('id')
-    .neq('id', null);
+    .from('tomato_activities')
+    .select('id');
 
   if (error) {
     console.error('Error fetching IDs:', error);
@@ -26,11 +25,10 @@ type PageProps = {
 
 export default async function Page({ params }: PageProps) {
   const id = Number(params.id);
-  const mainCategory = '대외활동';
 
   const { data: activityDetail, error } = await fetchActivityContestDetailWith(
     id,
-    mainCategory
+    'tomato_activities'
   );
 
   if (error || !activityDetail) {

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,29 +1,52 @@
-import { fetchActivityContestAbstractWith } from '@/lib/fetchActivityAbstractWith';
+import { fetchPaginatedData } from '@/lib/fetchPaginatedData';
 import Activity from '@/containers/activity/Activity';
 
 interface PageProps {
   searchParams: {
-    tab?: string;
+    page?: string;
     filters?: string;
     sort?: string;
   };
 }
 
 export default async function Page({ searchParams }: PageProps) {
+  // URL 파라미터 파싱
+  const currentPage = Number(searchParams.page) || 1;
   const filters = searchParams.filters?.split(',').filter(Boolean) || [];
-  const sort = searchParams.sort || '관련도순';
+  const itemsPerPage = 16;
+  const sort = (searchParams.sort || '관련도순') as
+    | '관련도순'
+    | '최신순'
+    | '조회순'
+    | '마감순';
 
-  const { data: activitiesContests, error } =
-    await fetchActivityContestAbstractWith({
-      filters,
-      sort,
-      mainCategory: '대외활동',
-    });
+  const {
+    data,
+    totalCount,
+    totalPages,
+    currentPage: page,
+    error,
+  } = await fetchPaginatedData({
+    page: currentPage,
+    itemsPerPage,
+    category: 'activity',
+    filters,
+    sort,
+  });
 
   if (error) {
     console.error('Error fetching activities:', error);
     return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
-  return <Activity activitiesContests={activitiesContests || []} />;
+  return (
+    <Activity
+      activities={data || []}
+      pagination={{
+        currentPage: page,
+        totalPages,
+        totalCount,
+      }}
+    />
+  );
 }

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,5 +1,6 @@
 import { fetchPaginatedData } from '@/lib/fetchPaginatedData';
 import Activity from '@/containers/activity/Activity';
+import { notFound } from 'next/navigation';
 
 interface PageProps {
   searchParams: {
@@ -39,9 +40,13 @@ export default async function Page({ searchParams }: PageProps) {
     return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
+  if (!data || data.length === 0) {
+    notFound();
+  }
+
   return (
     <Activity
-      activities={data || []}
+      activities={data}
       pagination={{
         currentPage: page,
         totalPages,

--- a/src/app/contest/[id]/page.tsx
+++ b/src/app/contest/[id]/page.tsx
@@ -4,9 +4,8 @@ import { supabase } from '@/lib/supabaseClient';
 
 export async function generateStaticParams() {
   const { data: posts, error } = await supabase
-    .from('activities_contests')
-    .select('id')
-    .neq('id', null);
+    .from('tomato_contests')
+    .select('id');
 
   if (error) {
     console.error('Error fetching IDs:', error);
@@ -26,17 +25,15 @@ type PageProps = {
 
 export default async function Page({ params }: PageProps) {
   const id = Number(params.id);
-  const mainCategory = '공모전';
 
   const { data: contestDetail, error } = await fetchActivityContestDetailWith(
     id,
-    mainCategory
+    'tomato_contests'
   );
 
   if (error || !contestDetail) {
     return <div>데이터 로딩 중 에러 발생</div>;
   }
 
-  // 개별 필드를 직접 전달
   return <ContestDetail {...contestDetail} />;
 }

--- a/src/app/contest/page.tsx
+++ b/src/app/contest/page.tsx
@@ -1,5 +1,6 @@
 import { fetchPaginatedData } from '@/lib/fetchPaginatedData';
 import Contest from '@/containers/contest/Contest';
+import { notFound } from 'next/navigation';
 
 interface PageProps {
   searchParams: {
@@ -38,9 +39,13 @@ export default async function Page({ searchParams }: PageProps) {
     return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
+  if (!data || data.length === 0) {
+    notFound();
+  }
+
   return (
     <Contest
-      contests={data || []}
+      contests={data}
       pagination={{
         currentPage: page,
         totalPages,

--- a/src/app/contest/page.tsx
+++ b/src/app/contest/page.tsx
@@ -1,30 +1,53 @@
-import { fetchActivityContestAbstractWith } from '@/lib/fetchActivityAbstractWith';
+import { fetchPaginatedData } from '@/lib/fetchPaginatedData';
 import Contest from '@/containers/contest/Contest';
 
 interface PageProps {
   searchParams: {
-    tab?: string;
+    page?: string;
     filters?: string;
     sort?: string;
   };
 }
 
 export default async function Page({ searchParams }: PageProps) {
+  const currentPage = Number(searchParams.page) || 1;
   const filters = searchParams.filters?.split(',').filter(Boolean) || [];
-  const sort = searchParams.sort || '관련도순';
+  const itemsPerPage = 16;
+  const sort = (searchParams.sort || '관련도순') as
+    | '관련도순'
+    | '최신순'
+    | '조회순'
+    | '마감순';
 
-  // 필터와 정렬 옵션을 API 호출에 전달
-  const { data: activitiesContests, error } =
-    await fetchActivityContestAbstractWith({
-      filters,
-      sort,
-      mainCategory: '공모전',
-    });
+  const {
+    data,
+    totalCount,
+    totalPages,
+    currentPage: page,
+    error,
+  } = await fetchPaginatedData({
+    page: currentPage,
+    itemsPerPage,
+    category: 'contest',
+    filters,
+    sort,
+  });
 
   if (error) {
     console.error('Error fetching activities:', error);
     return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
-  return <Contest activitiesContests={activitiesContests || []} />;
+  console.log(data);
+
+  return (
+    <Contest
+      contests={data || []}
+      pagination={{
+        currentPage: page,
+        totalPages,
+        totalCount,
+      }}
+    />
+  );
 }

--- a/src/app/contest/page.tsx
+++ b/src/app/contest/page.tsx
@@ -38,8 +38,6 @@ export default async function Page({ searchParams }: PageProps) {
     return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
-  console.log(data);
-
   return (
     <Contest
       contests={data || []}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,3 +14,23 @@
   font-weight: normal;
   font-style: normal;
 }
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(200, 200, 200, 0.2) 25%,
+    rgba(220, 220, 220, 0.5) 37%,
+    rgba(200, 200, 200, 0.2) 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-loading 1.4s ease infinite;
+}

--- a/src/components/skeleton/ActivityContestItemSkeleton.tsx
+++ b/src/components/skeleton/ActivityContestItemSkeleton.tsx
@@ -1,0 +1,19 @@
+export default function ActivityContestSkeleton() {
+  return (
+    <div className="w-full">
+      {/* Mobile Thumbnail */}
+      <div className="skeleton aspect-[3/4] w-full rounded-[20px] sm:hidden" />
+      {/* Desktop Thumbnail */}
+      <div className="skeleton hidden aspect-[5/6] w-full rounded-[20px] sm:block" />
+
+      <div className="mt-2 w-full md:mt-4">
+        <div className="skeleton mb-2 h-[3em] w-full md:h-[3.9em]" />
+        <div className="skeleton mb-2 h-6 w-3/4" />
+        <div className="flex items-center gap-1.5">
+          <div className="skeleton h-6 w-16 rounded-full" />
+          <div className="skeleton h-5 w-24" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeleton/HomeGridItemSkeleton.tsx
+++ b/src/components/skeleton/HomeGridItemSkeleton.tsx
@@ -1,0 +1,25 @@
+export default function HomeGridSkeleton() {
+  return (
+    <div className="relative">
+      {/* Mobile View */}
+      <div className="block w-full sm:hidden">
+        <div className="skeleton absolute ml-4 mt-5 h-8 w-20 rounded-full" />
+        <div className="skeleton h-[200px] w-full rounded-[20px]" />
+      </div>
+
+      {/* Desktop View */}
+      <div className="hidden w-full sm:block">
+        <div className="skeleton absolute ml-5 mt-5 h-9 w-24 rounded-full" />
+        <div className="skeleton h-[360px] w-full rounded-[20px]" />
+      </div>
+
+      <div className="mt-2 md:mt-4">
+        <div className="skeleton mb-2 h-12 w-full md:h-[78px]" />
+        <div className="flex items-center gap-1.5">
+          <div className="skeleton h-6 w-16 rounded-full" />
+          <div className="skeleton h-5 w-32" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeleton/TomatoTipSkeleton.tsx
+++ b/src/components/skeleton/TomatoTipSkeleton.tsx
@@ -1,0 +1,14 @@
+export default function TomatoTipSkeleton() {
+  return (
+    <div>
+      <div className="skeleton mb-3 h-[230px] rounded-[20px] md:mb-4 md:h-[290px]" />
+      <div className="flex h-10 flex-col items-start justify-between gap-2 md:h-[74px]">
+        <div className="inline-flex items-center gap-3">
+          <div className="skeleton h-6 w-16 rounded-full" />
+          <div className="skeleton h-5 w-3/4" />
+        </div>
+        <div className="skeleton hidden h-[30px] w-[120px] md:block" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/grid/ActivityContestItem.tsx
+++ b/src/components/ui/grid/ActivityContestItem.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import { formatViewCount } from '@/utils/format';
@@ -28,17 +29,12 @@ const ThumbnailImage = ({
 export default function ActivityContestItem({
   item,
 }: ActivityContestItemProps) {
-  const {
-    id,
-    title,
-    company,
-    d_day,
-    view_count,
-    main_category,
-    thumbnail_url,
-  } = item;
+  const { id, title, company, d_day, view_count, thumbnail_url } = item;
 
-  const detailUrl = useDetailUrl(id, main_category);
+  const pathname = usePathname();
+  const category = pathname.split('/')[1];
+
+  const detailUrl = useDetailUrl(id, category);
 
   return (
     <Link href={detailUrl} className="block w-full">

--- a/src/components/ui/navigation/Navigation.tsx
+++ b/src/components/ui/navigation/Navigation.tsx
@@ -3,6 +3,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import NavItem from './NavItem';
+import { useScroll } from '@/hooks/useScroll';
 
 type navItemType = {
   name: string;
@@ -11,6 +12,7 @@ type navItemType = {
 
 export default function Navigation() {
   const pathname = usePathname();
+  const isVisible = useScroll({ threshold: 90 });
 
   const navItems: navItemType[] = [
     { name: '매거진', route: '/magazine' },
@@ -18,8 +20,12 @@ export default function Navigation() {
     { name: '대외활동', route: '/activity' },
   ];
 
-  const containerClasses =
-    'flex flex-1 items-center fixed md:static bottom-[30px] left-1/2 transform -translate-x-1/2 md:transform-none z-50';
+  const containerClasses = `
+    flex flex-1 items-center fixed md:static bottom-[30px] left-1/2 
+    transform -translate-x-1/2 md:transform-none z-50
+    transition-all duration-300 ease-in-out
+    ${!isVisible ? 'opacity-0 translate-y-full pointer-events-none md:opacity-100 md:translate-y-0 md:pointer-events-auto' : 'opacity-100'}
+  `;
 
   const listClasses =
     'flex gap-6 lg:gap-10 bg-white h-full px-8 md:px-0 py-4 md:py-0 whitespace-nowrap shadow md:shadow-none border md:border-none border-sub-gray-100 rounded-full md:rounded-none items-center';

--- a/src/components/ui/pagination/Pagination.tsx
+++ b/src/components/ui/pagination/Pagination.tsx
@@ -2,59 +2,22 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import GridView from '../grid/GridView';
 import PaginationControl from './PaginationControl';
-import useResponsiveItemsPerPage from '@/hooks/useResponsiveItemsPerPage';
 import { notFound } from 'next/navigation';
 
-/**
- * Pagination 컴포넌트는 주어진 콘텐츠를 그리드 형식으로 페이징 처리하여 렌더링합니다.
- * 화면 크기에 따라 한 페이지당 아이템 수를 조절하고, 페이지네이션을 적용하여 사용자에게 콘텐츠를 나눠서 보여줍니다.
- *
- * @template T - 콘텐츠의 항목 타입을 나타냅니다.
- *
- * @param {T[]} contents - 페이징 처리할 전체 콘텐츠 배열입니다.
- * @param {React.ComponentType<GridItemProps<T>>} GridItem - 각 콘텐츠 항목을 렌더링할 컴포넌트입니다.
- * @param {number} webItemPerPage - 웹 환경에서 한 페이지에 보여줄 아이템 수입니다.
- * @param {number} mobileItemPerPage - 모바일 환경에서 한 페이지에 보여줄 아이템 수입니다.
- * @param {{ mobile: number, web: number }} columns - 모바일 및 웹에서의 그리드 열 수를 정의합니다.
- * @param {GapStyles} gapStyle - 그리드 아이템 간의 간격 스타일을 선택합니다.
- *    - 'gapStyle1': BEST PICK, 토마토들 추천활동, 토마토 Pick에 사용됩니다.
- *    - 'gapStyle2': 대외활동, 공모전에 사용됩니다.
- *    - 'gapStyle3': 토마토 Tip에 사용됩니다.
- *
- * @returns {JSX.Element} 페이징 처리된 그리드와 페이지네이션 컨트롤을 포함한 JSX 요소를 반환합니다.
- *
- * @throws {Error} 현재 페이지가 1보다 작거나, 총 페이지 수를 초과할 경우 404 페이지로 리디렉션됩니다.
- */
-
 export default function Pagination<T>({
-  contents,
+  items,
   GridItem,
-  webItemPerPage,
-  mobileItemPerPage,
   columnStyle,
   gapStyle,
-}: PaginationProps<T>) {
+  pagination,
+}: PaginationUIProps<T>) {
   const router = useRouter();
   const searchParams = useSearchParams();
-
-  const currentPage = parseInt(searchParams.get('page') || '1', 10);
-
-  const itemsPerPage = useResponsiveItemsPerPage(
-    webItemPerPage,
-    mobileItemPerPage
-  );
-
-  const totalItems = contents.length;
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const { currentPage, totalPages } = pagination;
 
   if (currentPage < 1 || currentPage > totalPages) {
     notFound();
   }
-
-  const currentItems = contents.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
 
   const handlePageChange = (page: number) => {
     if (page > 0 && page <= totalPages) {
@@ -67,7 +30,7 @@ export default function Pagination<T>({
   return (
     <section className="flex flex-col gap-4">
       <GridView<T>
-        items={currentItems}
+        items={items}
         GridItem={GridItem}
         columnStyle={columnStyle}
         gapStyle={gapStyle}

--- a/src/components/ui/pagination/PaginationOld.tsx
+++ b/src/components/ui/pagination/PaginationOld.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import GridView from '../grid/GridView';
+import PaginationControl from './PaginationControl';
+import useResponsiveItemsPerPage from '@/hooks/useResponsiveItemsPerPage';
+import { notFound } from 'next/navigation';
+
+/**
+ * Pagination 컴포넌트는 주어진 콘텐츠를 그리드 형식으로 페이징 처리하여 렌더링합니다.
+ * 화면 크기에 따라 한 페이지당 아이템 수를 조절하고, 페이지네이션을 적용하여 사용자에게 콘텐츠를 나눠서 보여줍니다.
+ *
+ * @template T - 콘텐츠의 항목 타입을 나타냅니다.
+ *
+ * @param {T[]} contents - 페이징 처리할 전체 콘텐츠 배열입니다.
+ * @param {React.ComponentType<GridItemProps<T>>} GridItem - 각 콘텐츠 항목을 렌더링할 컴포넌트입니다.
+ * @param {number} webItemPerPage - 웹 환경에서 한 페이지에 보여줄 아이템 수입니다.
+ * @param {number} mobileItemPerPage - 모바일 환경에서 한 페이지에 보여줄 아이템 수입니다.
+ * @param {{ mobile: number, web: number }} columns - 모바일 및 웹에서의 그리드 열 수를 정의합니다.
+ * @param {GapStyles} gapStyle - 그리드 아이템 간의 간격 스타일을 선택합니다.
+ *    - 'gapStyle1': BEST PICK, 토마토들 추천활동, 토마토 Pick에 사용됩니다.
+ *    - 'gapStyle2': 대외활동, 공모전에 사용됩니다.
+ *    - 'gapStyle3': 토마토 Tip에 사용됩니다.
+ *
+ * @returns {JSX.Element} 페이징 처리된 그리드와 페이지네이션 컨트롤을 포함한 JSX 요소를 반환합니다.
+ *
+ * @throws {Error} 현재 페이지가 1보다 작거나, 총 페이지 수를 초과할 경우 404 페이지로 리디렉션됩니다.
+ */
+
+export default function PaginationOld<T>({
+  contents,
+  GridItem,
+  webItemPerPage,
+  mobileItemPerPage,
+  columnStyle,
+  gapStyle,
+}: PaginationOldProps<T>) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentPage = parseInt(searchParams.get('page') || '1', 10);
+
+  const itemsPerPage = useResponsiveItemsPerPage(
+    webItemPerPage,
+    mobileItemPerPage
+  );
+
+  const totalItems = contents.length;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  if (currentPage < 1 || currentPage > totalPages) {
+    notFound();
+  }
+
+  const currentItems = contents.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
+
+  const handlePageChange = (page: number) => {
+    if (page > 0 && page <= totalPages) {
+      const newQuery = new URLSearchParams(searchParams);
+      newQuery.set('page', String(page));
+      router.push(`?${newQuery.toString()}`);
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <GridView<T>
+        items={currentItems}
+        GridItem={GridItem}
+        columnStyle={columnStyle}
+        gapStyle={gapStyle}
+      />
+      <PaginationControl
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
+    </section>
+  );
+}

--- a/src/containers/activity/Activity.tsx
+++ b/src/containers/activity/Activity.tsx
@@ -4,28 +4,30 @@ import NoFilterResult from '@/components/common/noFilterResult';
 import { Suspense } from 'react';
 
 interface ActivityProps {
-  activitiesContests: ContestActivityData[];
+  activities: ActivityContestData[];
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalCount: number;
+  };
 }
 
-export default function Activity({ activitiesContests }: ActivityProps) {
-  if (activitiesContests.length === 0) {
+export default function Activity({ activities, pagination }: ActivityProps) {
+  if (activities.length === 0) {
     return <NoFilterResult />;
   }
 
   return (
-    <>
+    <div className="px-7 md:px-[88px]">
       <Suspense fallback={<div>로딩 중...</div>}>
-        <div className="px-7 md:px-[88px]">
-          <Pagination
-            contents={activitiesContests}
-            GridItem={ActivityContestItem}
-            webItemPerPage={16}
-            mobileItemPerPage={10}
-            columnStyle="web4mobile2"
-            gapStyle="gapStyle2"
-          />
-        </div>
+        <Pagination
+          items={activities}
+          GridItem={ActivityContestItem}
+          columnStyle="web4mobile2"
+          gapStyle="gapStyle2"
+          pagination={pagination}
+        />
       </Suspense>
-    </>
+    </div>
   );
 }

--- a/src/containers/activity/ActivityDetail.tsx
+++ b/src/containers/activity/ActivityDetail.tsx
@@ -7,23 +7,6 @@ import ActivityContestDescription from '@/components/common/ActivityContestDescr
 import { formatDate } from '@/utils/format';
 import { useState } from 'react';
 
-type ActivityContestDetailProps = {
-  thumbnail_url: string;
-  title: string;
-  registration_date: string;
-  view_count: number;
-  start_date: string;
-  end_date: string;
-  company: string;
-  homepage_url: string;
-  d_day: number;
-  description: string;
-  department?: string;
-  target?: string;
-  field?: string;
-  duration?: string;
-};
-
 export default function ActivityDetail({
   thumbnail_url,
   title,
@@ -37,7 +20,7 @@ export default function ActivityDetail({
   description,
   field,
   duration,
-}: ActivityContestDetailProps) {
+}: ActivityContestDetail) {
   const [activeTab, setActiveTab] = useState('상세내용');
   const [formatted_start_date, formatted_end_date] = [
     formatDate(start_date),

--- a/src/containers/contest/Contest.tsx
+++ b/src/containers/contest/Contest.tsx
@@ -4,11 +4,16 @@ import NoFilterResult from '@/components/common/noFilterResult';
 import { Suspense } from 'react';
 
 interface ContestProps {
-  activitiesContests: ContestActivityData[];
+  contests: ActivityContestData[];
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalCount: number;
+  };
 }
 
-export default function Contest({ activitiesContests }: ContestProps) {
-  if (activitiesContests.length === 0) {
+export default function Contest({ contests, pagination }: ContestProps) {
+  if (contests.length === 0) {
     return <NoFilterResult />;
   }
 
@@ -17,12 +22,11 @@ export default function Contest({ activitiesContests }: ContestProps) {
       <Suspense fallback={<div>로딩 중...</div>}>
         <div className="px-7 md:px-[88px]">
           <Pagination
-            contents={activitiesContests}
+            items={contests}
             GridItem={ActivityContestItem}
-            webItemPerPage={16}
-            mobileItemPerPage={10}
             columnStyle="web4mobile2"
             gapStyle="gapStyle2"
+            pagination={pagination}
           />
         </div>
       </Suspense>

--- a/src/containers/contest/ContestDetail.tsx
+++ b/src/containers/contest/ContestDetail.tsx
@@ -7,23 +7,6 @@ import ActivityContestDescription from '@/components/common/ActivityContestDescr
 import { formatDate } from '@/utils/format';
 import { useState } from 'react';
 
-type ActivityContestDetailProps = {
-  thumbnail_url: string;
-  title: string;
-  registration_date: string;
-  view_count: number;
-  start_date: string;
-  end_date: string;
-  company: string;
-  homepage_url: string;
-  d_day: number;
-  description: string;
-  department?: string;
-  target?: string;
-  field?: string;
-  duration?: string;
-};
-
 export default function ContestDetail({
   thumbnail_url,
   title,
@@ -37,7 +20,7 @@ export default function ContestDetail({
   description,
   department,
   target,
-}: ActivityContestDetailProps) {
+}: ActivityContestDetail) {
   const [activeTab, setActiveTab] = useState('상세내용');
   const [formatted_start_date, formatted_end_date] = [
     formatDate(start_date),

--- a/src/containers/magazine/MtomatoPick.tsx
+++ b/src/containers/magazine/MtomatoPick.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import Pagination from '@/components/ui/pagination/Pagination';
+import PaginationOld from '@/components/ui/pagination/PaginationOld';
 import HomeGridItem from '@/containers/home/HomeGridItem';
 import { fetchBestPickAll } from '@/lib/fetchBestPickGridView';
 import { useSearchParams } from 'next/navigation';
@@ -59,7 +59,7 @@ const MtomatoPick = () => {
 
       <div className="mb-[72px] mt-[28px] flex flex-col items-center md:mb-[120px] md:mt-[40px] md:items-start">
         {tomatoPicks.length > 0 && (
-          <Pagination
+          <PaginationOld
             contents={tomatoPicks}
             GridItem={HomeGridItem}
             webItemPerPage={8}

--- a/src/containers/magazine/TomatoTips.tsx
+++ b/src/containers/magazine/TomatoTips.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from 'react';
 import { TomatoTipDataType } from '@/types/tomatoTips';
 import { fetchAllTomatoTips } from '@/lib/fetchTomatoTip';
-import Pagination from '@/components/ui/pagination/Pagination';
+import PaginationOld from '@/components/ui/pagination/PaginationOld';
 import TomatoTipItem from './TomatoTipItem';
 
 const TomatoTips = () => {
@@ -11,7 +11,7 @@ const TomatoTips = () => {
 
   useEffect(() => {
     const fetchTips = async () => {
-      const { data, error } = await fetchAllTomatoTips(); 
+      const { data, error } = await fetchAllTomatoTips();
 
       if (error) {
         console.error('Error fetching tips:', error);
@@ -32,7 +32,7 @@ const TomatoTips = () => {
         {tips.length > 0 && (
           <>
             <Suspense fallback={<div>로딩 중...</div>}>
-              <Pagination
+              <PaginationOld
                 contents={tips}
                 GridItem={TomatoTipItem}
                 webItemPerPage={15}

--- a/src/hooks/useResponsiveItemsPerPage.tsx
+++ b/src/hooks/useResponsiveItemsPerPage.tsx
@@ -1,3 +1,5 @@
+// 웹과 모바일에서 페이지 당 아이템 개수를 동일하게 유지하도록 했기 때문에 이 훅은 삭제 예정입니다
+
 import { useState, useEffect } from 'react';
 
 export default function useResponsiveItemsPerPage(
@@ -9,13 +11,13 @@ export default function useResponsiveItemsPerPage(
   useEffect(() => {
     function handleResize() {
       if (window.innerWidth >= 768) {
-        setItemsPerPage(webItemsPerPage); 
+        setItemsPerPage(webItemsPerPage);
       } else {
         setItemsPerPage(mobileItemsPerPage);
       }
     }
 
-    handleResize(); 
+    handleResize();
     window.addEventListener('resize', handleResize);
 
     return () => {

--- a/src/hooks/useScroll.tsx
+++ b/src/hooks/useScroll.tsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+interface UseScrollOptions {
+  threshold?: number;
+}
+
+export function useScroll({ threshold = 20 }: UseScrollOptions = {}) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      const currentScroll = window.scrollY;
+      const scrollPercent = (currentScroll / scrollHeight) * 100;
+
+      setIsVisible(scrollPercent < threshold);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [threshold]);
+
+  return isVisible;
+}

--- a/src/lib/fetchActivityContestDetailWith.ts
+++ b/src/lib/fetchActivityContestDetailWith.ts
@@ -1,69 +1,48 @@
 import { supabase } from './supabaseClient';
 import { PostgrestError } from '@supabase/supabase-js';
 
-type ActivityContestDetail = {
-  thumbnail_url: string;
-  title: string;
-  registration_date: string;
-  view_count: number;
-  start_date: string;
-  end_date: string;
-  company: string;
-  homepage_url: string;
-  d_day: number;
-  description: string;
-  department?: string;
-  target?: string;
-  field?: string;
-  duration?: string;
-};
+type TableName = 'tomato_activities' | 'tomato_contests';
 
 /**
- * Fetches detailed information for a specific activity or contest item from Supabase.
+ * 특정 대외활동 또는 공모전의 상세 정보를 가져옵니다.
  *
  * @async
  * @function fetchActivityContestDetailWith
- * @param {number} id - The unique identifier of the activity or contest item.
- * @param {string} mainCategory - The main category, which determines additional fields to include.
- *                                - `'공모전'`: Includes `department` and `target` fields.
- *                                - `'대외활동'`: Includes `field` and `duration` fields.
+ * @param {number} id - 조회할 항목의 고유 식별자
+ * @param {TableName} tableName - 조회할 테이블 이름 ('tomato_activities' 또는 'tomato_contests')
  *
  * @returns {Promise<{data: ActivityContestDetail | null, error: PostgrestError | null}>}
- *          A promise that resolves to an object containing:
- *          - `data`: The detailed information of the specified item or `null` if an error occurred.
- *          - `error`: Supabase's `PostgrestError` object or `null` if no error occurred.
- *
- * @throws Will log an error if the data fetching fails.
+ *          Promise 객체는 다음을 포함합니다:
+ *          - `data`: 조회된 항목의 상세 정보 또는 에러 발생 시 `null`
+ *          - `error`: Supabase의 `PostgrestError` 객체 또는 에러가 없을 경우 `null`
  *
  * @example
- * // Fetch the details of an activity with ID 1 and main category '대외활동'
- * const { data, error } = await fetchActivityContestDetailWith(1, '대외활동');
+ * // 대외활동 상세 정보 조회
+ * const { data, error } = await fetchActivityContestDetailWith(1, 'tomato_activities');
  *
- * if (error) {
- *   console.error('Error fetching detail:', error);
- * } else {
- *   console.log('Activity Contest Detail:', data);
- * }
+ * // 공모전 상세 정보 조회
+ * const { data, error } = await fetchActivityContestDetailWith(1, 'tomato_contests');
  */
 export const fetchActivityContestDetailWith = async (
   id: number,
-  mainCategory: string
+  tableName: TableName
 ): Promise<{
   data: ActivityContestDetail | null;
   error: PostgrestError | null;
 }> => {
   try {
+    // 테이블에 따른 추가 필드 설정
     let selectFields =
       'thumbnail_url, title, registration_date, view_count, start_date, end_date, company, homepage_url, d_day, description';
 
-    if (mainCategory === '공모전') {
+    if (tableName === 'tomato_contests') {
       selectFields += ', department, target';
-    } else if (mainCategory === '대외활동') {
+    } else if (tableName === 'tomato_activities') {
       selectFields += ', field, duration';
     }
 
     const { data, error } = await supabase
-      .from('activities_contests')
+      .from(tableName)
       .select(selectFields)
       .eq('id', id)
       .single();

--- a/src/lib/fetchPaginatedData.ts
+++ b/src/lib/fetchPaginatedData.ts
@@ -1,0 +1,157 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+const TABLE_MAPPING = {
+  activity: 'tomato_activities',
+  contest: 'tomato_contests',
+  tips: 'tomato_tips',
+} as const;
+
+/**
+ * 데이터베이스 쿼리에 필터 조건을 적용합니다.
+ * activity와 contest 카테고리에만 필터가 적용됩니다.
+ * @template T - CategoryType의 키 타입
+ * @param query - Supabase 쿼리 객체
+ * @param category - 데이터 카테고리 ('activity' | 'contest' | 'tips')
+ * @param filters - 적용할 필터 문자열 배열
+ * @returns 필터가 적용된 쿼리 객체
+ */
+function applyFilters<T extends keyof CategoryType>(
+  query: SupabaseClient['from']['prototype']['select'],
+  category: T,
+  filters?: string[]
+) {
+  if (!filters?.length || (category !== 'activity' && category !== 'contest')) {
+    return query;
+  }
+
+  const filterColumns =
+    category === 'activity'
+      ? ['field', 'activity', 'host', 'duration', 'region']
+      : ['department', 'prize_amount', 'prize_benefit', 'target', 'organizer'];
+
+  const orConditions = filters.flatMap((filter) =>
+    filterColumns.map((column) => `${column}.ilike.%${filter}%`)
+  );
+
+  return orConditions.length > 0 ? query.or(orConditions.join(',')) : query;
+}
+
+/**
+ * 데이터베이스 쿼리에 정렬 조건을 적용합니다.
+ * activity와 contest 카테고리는 지정된 정렬 옵션을 사용하고,
+ * tips 카테고리는 생성일 기준 내림차순으로 정렬됩니다.
+ * @template T - CategoryType의 키 타입
+ * @param query - Supabase 쿼리 객체
+ * @param category - 데이터 카테고리 ('activity' | 'contest' | 'tips')
+ * @param sort - 정렬 옵션
+ * @returns 정렬이 적용된 쿼리 객체
+ */
+function applySort<T extends keyof CategoryType>(
+  query: SupabaseClient['from']['prototype']['select'],
+  category: T,
+  sort?: '관련도순' | '최신순' | '조회순' | '마감순'
+) {
+  if (category === 'activity' || category === 'contest') {
+    switch (sort) {
+      case '최신순':
+        return query.order('registration_date', { ascending: false });
+      case '조회순':
+        return query.order('view_count', { ascending: false });
+      case '마감순':
+        return query.order('d_day', { ascending: true });
+      default:
+        return query.order('registration_date', { ascending: false });
+    }
+  }
+
+  return query.order('created_at', { ascending: false });
+}
+
+/**
+ * 데이터베이스 쿼리에 페이지네이션을 적용합니다.
+ * @param query - Supabase 쿼리 객체
+ * @param page - 현재 페이지 번호
+ * @param itemsPerPage - 페이지당 항목 수
+ * @returns 페이지네이션이 적용된 쿼리 객체
+ */
+function applyPagination(
+  query: SupabaseClient['from']['prototype']['select'],
+  page: number,
+  itemsPerPage: number
+) {
+  const from = (page - 1) * itemsPerPage;
+  const to = from + itemsPerPage - 1;
+  return query.range(from, to);
+}
+
+/**
+ * 대외활동, 공모전, 팁 데이터를 페이지네이션, 필터링, 정렬하여 가져오는 함수입니다.
+ *
+ * @template T - CategoryType의 키 타입 ('activity' | 'contest' | 'tips')
+ * @param options - 페이지네이션 옵션
+ * @param options.page - 현재 페이지 번호 (기본값: 1)
+ * @param options.itemsPerPage - 페이지당 항목 수 (기본값: 10)
+ * @param options.category - 데이터 카테고리
+ * @param options.filters - 필터 조건 배열 (activity, contest 카테고리만 적용)
+ * @param options.sort - 정렬 옵션 (activity, contest 카테고리만 적용)
+ *
+ * @returns 페이지네이션된 데이터와 메타 정보
+ *
+ * @example
+ * // 대외활동 데이터 조회
+ * const result = await fetchPaginatedData({
+ *   category: 'activity',
+ *   page: 1,
+ *   itemsPerPage: 10,
+ *   filters: ['서울', '마케팅'],
+ *   sort: '최신순'
+ * });
+ *
+ * // 팁 데이터 조회 (필터, 정렬 옵션 없이)
+ * const tips = await fetchPaginatedData({
+ *   category: 'tips',
+ *   page: 1,
+ *   itemsPerPage: 20
+ * });
+ */
+export async function fetchPaginatedData<T extends keyof CategoryType>({
+  page = 1,
+  itemsPerPage = 10,
+  category,
+  filters,
+  sort,
+}: PaginationParams<T>): Promise<PaginationResult<CategoryType[T]>> {
+  try {
+    const tableName = TABLE_MAPPING[category];
+
+    let query = supabase.from(tableName).select('*', { count: 'exact' });
+    query = applyFilters(query, category, filters);
+    query = applySort(query, category, sort);
+    query = applyPagination(query, page, itemsPerPage);
+
+    const { data, count, error } = await query;
+
+    if (error) throw error;
+
+    const totalCount = count || 0;
+    const totalPages = Math.ceil(totalCount / itemsPerPage);
+
+    return {
+      data: data as CategoryType[T][],
+      totalCount,
+      totalPages,
+      currentPage: page,
+      error: null,
+    };
+  } catch (error) {
+    console.error('데이터 fetch 중 에러 발생:', error);
+    return {
+      data: null,
+      totalCount: 0,
+      totalPages: 0,
+      currentPage: page,
+      error: error as Error,
+    };
+  }
+}

--- a/src/lib/fetchPaginatedData.ts
+++ b/src/lib/fetchPaginatedData.ts
@@ -1,4 +1,4 @@
-import { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabase } from './supabaseClient';
 
 const TABLE_MAPPING = {

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -9,6 +9,23 @@ type ActivityContestDetailsProps = {
   detailUrl: string;
 };
 
+type ActivityContestDetail = {
+  thumbnail_url: string;
+  title: string;
+  registration_date: string;
+  view_count: number;
+  start_date: string;
+  end_date: string;
+  company: string;
+  homepage_url: string;
+  d_day: number;
+  description: string;
+  department?: string;
+  target?: string;
+  field?: string;
+  duration?: string;
+};
+
 type ActivityContestListProps = {
   item: ActivityContestDetailProps;
 };
@@ -50,6 +67,7 @@ type MainSliderDataProps = {
   thumbnail_url: string;
   homepage_url: string;
   dominant_color: string;
+  category_id: number;
 };
 
 type MainSliderListProps = {
@@ -66,6 +84,7 @@ type ContestActivityDataProps = {
   main_category: '공모전' | '대외활동';
   thumbnail_url: string;
   homepage_url: string;
+  category_id: number;
 };
 
 type ContestActivityDataPropsWithViewCount = {
@@ -94,8 +113,17 @@ type ContestActivityData = {
   thumbnail_url: string;
 };
 
+type ActivityContestData = {
+  id: number;
+  title: string;
+  company: string;
+  d_day: number;
+  view_count: number;
+  thumbnail_url: string;
+};
+
 type ActivityContestItemProps = {
-  item: ContestActivityData;
+  item: ActivityContestData;
 };
 
 type FetchActivityContestAbstractParams = {

--- a/src/types/grid.d.ts
+++ b/src/types/grid.d.ts
@@ -6,15 +6,6 @@ type SlideColumnStyles = 'web3mobile3' | 'web6mobile6';
 
 type SlideGaptyles = 'slideGapStyle1' | 'slideGapStyle2';
 
-type PaginationProps<T> = {
-  contents: T[];
-  GridItem: React.ComponentType<GridItemProps<T>>;
-  webItemPerPage: number;
-  mobileItemPerPage: number;
-  columnStyle: GridColumns; 
-  gapStyle: GapStyles; 
-};
-
 type GridViewProps<T> = {
   items: T[];
   GridItem: React.ComponentType<{ item: T }>;

--- a/src/types/pagination.d.ts
+++ b/src/types/pagination.d.ts
@@ -1,0 +1,92 @@
+// 구 페이지네이션 컴포넌트 타입
+type PaginationOldProps<T> = {
+  contents: T[];
+  GridItem: React.ComponentType<GridItemProps<T>>;
+  webItemPerPage: number;
+  mobileItemPerPage: number;
+  columnStyle: GridColumns;
+  gapStyle: GapStyles;
+};
+
+type PaginationUIProps<T> = {
+  items: T[];
+  GridItem: React.ComponentType<{ item: T }>;
+  columnStyle: GridColumns;
+  gapStyle: GapStyles;
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalCount: number;
+  };
+};
+
+type PaginationProps<T> = {
+  contents: T[];
+  GridItem: React.ComponentType<GridItemProps<T>>;
+  itemPerPage: number;
+  columnStyle: GridColumns;
+  gapStyle: GapStyles;
+};
+
+interface BaseItem {
+  id: number;
+  title: string;
+  company: string;
+  view_count: number;
+  thumbnail_url: string;
+  start_date: string;
+  end_date: string;
+  award_info: string;
+  dominant_color: string;
+  description: string;
+  homepage_url: string;
+  registration_date: string;
+  created_at: string;
+  updated_at: string;
+  d_day: number;
+}
+
+interface Activity extends BaseItem {
+  field: string;
+  activity: string;
+  host: string;
+  duration: string;
+  region: string;
+}
+
+interface Contest extends BaseItem {
+  department: string;
+  prize_amount: string;
+  prize_benefit: string;
+  target: string;
+  organizer: string;
+}
+
+type CategoryType = {
+  activity: Activity;
+  contest: Contest;
+  tips: Tip;
+};
+
+type FilterableSortableCategory = Extract<
+  keyof CategoryType,
+  'activity' | 'contest'
+>;
+
+interface PaginationParams<T extends keyof CategoryType> {
+  page: number;
+  itemsPerPage: number;
+  category: T;
+  filters?: T extends FilterableSortableCategory ? string[] : never;
+  sort?: T extends FilterableSortableCategory
+    ? '관련도순' | '최신순' | '조회순' | '마감순'
+    : never;
+}
+
+interface PaginationResult<T> {
+  data: T[] | null;
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+  error: Error | null;
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,9 +1,6 @@
 import { useSearchParams } from 'next/navigation';
 
-export const useDetailUrl = (
-  id: number,
-  mainCategory: '공모전' | '대외활동'
-) => {
+export const useDetailUrl = (id: number, category: string) => {
   const searchParams = useSearchParams();
 
   const getQueryParams = () => {
@@ -18,8 +15,8 @@ export const useDetailUrl = (
     return params.toString();
   };
 
-  const baseUrl =
-    mainCategory === '공모전' ? `/contest/${id}` : `/activity/${id}`;
+  // 현재 route에 기반한 baseUrl 생성
+  const baseUrl = `/${category}/${id}`;
   const queryString = getQueryParams();
 
   return queryString ? `${baseUrl}?${queryString}` : baseUrl;


### PR DESCRIPTION
# 변경 사항
이번 PR에서는 페이지네이션 기능 및 UI와 관련된 대규모 리팩토링이 진행됐습니다. 또한 모바일 내비게이션의 숨김 처리 기능도 추가적으로 구현했습니다.

## Supabase
이제 activities_contests 뿐만 아니라 tomato_activities, tomato_contests 테이블을 생성했습니다. 대외활동과 공모전에 따라 각각 다른 데이터를 불러올 수 있습니다. 또한 tomato_activities 및 tomato_contests의 id를 activities_contests의 새로운 칼럼인 category_id에 추가해, 홈 화면에서 대외활동 혹은 공모전 아이템을 클릭했을 때 상세 페이지로 이동하기 위한 사전 작업을 완료했습니다.

## 페이지네이션

### 기존 페이지네이션의 문제점
기존 페이지네이션의 컴포넌트와 기능은 모두 **클라이언트에서 페이지네이션을 진행**하는 것에 초점을 두고 잘못 설계되었습니다. 따라서 이를 대대적으로 수정했습니다.

이제 페이지네이션은 서버에서 이루어지며, 새롭게 구성된 컴포넌트와 함수가 그 역할을 수행합니다. (기존에 사용하던 페이지네이션 컴포넌트는 `PaginationOld`로 이름을 변경했습니다)

### `fetchPaginatedData`
https://github.com/hminah0215/tomatoes/commit/8ad715f51841c4f3f40ffdff5adb90d79ab9a5b7
대외활동 및 공모전 뿐만 아니라, 매거진의 토마토 팁에서도 사용 가능한 페이지네이션입니다. 이제 함수의 인자로 현재 페이지, 페이지당 아이템, 카테고리, 필터와 정렬(옵셔널입니다)을 주고, 결과로 현재 페이지에 해당하는 아이템과 총 페이지 수를 받아올 수 있도록 했습니다.
```ts
export async function fetchPaginatedData<T extends keyof CategoryType>({
  page = 1,
  itemsPerPage = 10,
  category,
  filters,
  sort,
}: PaginationParams<T>): Promise<PaginationResult<CategoryType[T]>> {
  try {
    const tableName = TABLE_MAPPING[category];

    let query = supabase.from(tableName).select('*', { count: 'exact' });
    query = applyFilters(query, category, filters);
    query = applySort(query, category, sort);
    query = applyPagination(query, page, itemsPerPage);

    const { data, count, error } = await query;

    if (error) throw error;

    const totalCount = count || 0;
    const totalPages = Math.ceil(totalCount / itemsPerPage);

    return {
      data: data as CategoryType[T][],
      totalCount,
      totalPages,
      currentPage: page,
      error: null,
    };
  } catch (error) {
    console.error('데이터 fetch 중 에러 발생:', error);
    return {
      data: null,
      totalCount: 0,
      totalPages: 0,
      currentPage: page,
      error: error as Error,
    };
  }
}
```

### `Pagination`
https://github.com/hminah0215/tomatoes/commit/07455363d1582e26bc4295796084908a23d8e144
이제 웹과 모바일에서 페이지 당 컨텐츠 수를 동일하게 가져가기로 했고, 페이지네이션 계산을 컴포넌트에서 직접 하지 않기 때문에 이와 관련된 코드를  제거한 새로운 페이지네이션 컴포넌트를 구현했습니다. (기존 페이지네이션 컴포넌트의 이름은 PaginationOld 로 변경)

또한 모든 페이지네이션 컴포넌트 교체 작업이 완료되면 `useResponsiveItemsPerPage` 훅은 삭제할 예정입니다.

## 스켈레톤
https://github.com/hminah0215/tomatoes/commit/afb658200083fe62e3cedf8d5e266f6787d4b8a3
- `ActivityContestItem`, `HomeGridItem`, `TomatoTip`에 대한 스켈레톤 UI를 구현했습니다.
- 정상 적용 여부는 추후 확인 필요


## 모바일 내비게이션 바
- 이제 `useScroll` 훅을 사용해 모바일 내비게이션바가 화면의 일정 영역 이하로 스크롤될 경우 숨겨져 푸터를 가리지 않습니다.

![모바일내비게이션바](https://github.com/user-attachments/assets/718d3970-f654-4ae6-b2a5-7f2fe99157e0)

```tsx
import { useState, useEffect } from 'react';

interface UseScrollOptions {
  threshold?: number;
}

export function useScroll({ threshold = 20 }: UseScrollOptions = {}) {
  const [isVisible, setIsVisible] = useState(true);

  useEffect(() => {
    const handleScroll = () => {
      const scrollHeight =
        document.documentElement.scrollHeight - window.innerHeight;
      const currentScroll = window.scrollY;
      const scrollPercent = (currentScroll / scrollHeight) * 100;

      setIsVisible(scrollPercent < threshold);
    };

    window.addEventListener('scroll', handleScroll, { passive: true });
    handleScroll();

    return () => {
      window.removeEventListener('scroll', handleScroll);
    };
  }, [threshold]);

  return isVisible;
}
```

# 관련 이슈
#77 

# 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [ ] 리팩토링 (기능 변경 없음)

# 체크리스트
- [ ] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [ ] 필요한 경우, 주석을 추가했습니다.

# 추가 정보


