### PR TITLE
Design, Refactor: Home/Magazine Refactoring ver.2

### DIFF
--- a/src/components/ui/grid/ActivityContestItem.tsx
+++ b/src/components/ui/grid/ActivityContestItem.tsx
@@ -5,6 +5,7 @@ import Dday from '@/components/common/Dday';
 import { formatViewCount } from '@/utils/format';
 import Link from 'next/link';
 import { useDetailUrl } from '@/utils/url';
+import { formatDate, dateToFormatDate } from '@/utils/format';
 
 const ThumbnailImage = ({
   url,
@@ -29,12 +30,19 @@ const ThumbnailImage = ({
 export default function ActivityContestItem({
   item,
 }: ActivityContestItemProps) {
-  const { id, title, company, d_day, view_count, thumbnail_url } = item;
+  const { id, title, company, d_day, start_date, end_date, view_count, thumbnail_url } = item;
 
   const pathname = usePathname();
   const category = pathname.split('/')[1];
 
   const detailUrl = useDetailUrl(id, category);
+
+  const today_date = new Date();
+  const [formatted_today_date, formatted_start_date, formatted_end_date] = [
+    dateToFormatDate(today_date),
+    formatDate(start_date),
+    formatDate(end_date),
+  ];
 
   return (
     <Link href={detailUrl} className="block w-full">
@@ -51,7 +59,17 @@ export default function ActivityContestItem({
         </p>
 
         <div className="flex items-center gap-1.5">
-          <Dday type="active" day={d_day} color="red" />
+          {formatted_start_date > formatted_today_date ? (
+            <Dday type="upcoming" />
+          ) : formatted_end_date < formatted_today_date ? (
+            <Dday type="completed" />
+          ) : (
+            <Dday
+              type="active"
+              day={d_day}
+              color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'}
+            />
+          )}
           <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:text-base md:font-medium">
             조회 {formatViewCount(view_count)}회
           </p>

--- a/src/containers/activity/ActivityDetail.tsx
+++ b/src/containers/activity/ActivityDetail.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
 import ActivityContestDescription from '@/components/common/ActivityContestDescription';
-import { formatDate } from '@/utils/format';
+import { formatDate, dateToFormatDate } from '@/utils/format';
 import { useState } from 'react';
 
 export default function ActivityDetail({
@@ -22,7 +22,9 @@ export default function ActivityDetail({
   duration,
 }: ActivityContestDetail) {
   const [activeTab, setActiveTab] = useState('상세내용');
-  const [formatted_start_date, formatted_end_date] = [
+  const today_date = new Date();
+  const [formatted_today_date, formatted_start_date, formatted_end_date] = [
+    dateToFormatDate(today_date),
     formatDate(start_date),
     formatDate(end_date),
   ];
@@ -83,7 +85,17 @@ export default function ActivityDetail({
         <ThumbnailImage url={thumbnail_url} title={title} isMobile={false} />
 
         <div className="flex-1">
-          <Dday type="active" day={d_day} color="red" />
+          {formatted_start_date > formatted_today_date ? (
+            <Dday type="upcoming" />
+          ) : formatted_end_date < formatted_today_date ? (
+            <Dday type="completed" />
+          ) : (
+            <Dday
+              type="active"
+              day={d_day}
+              color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'}
+            />
+          )}
           <h2 className="mb-2 mt-3 break-all text-2xl font-bold leading-normal text-sub-gray-500 md:text-5xl">
             {title}
           </h2>

--- a/src/containers/contest/ContestDetail.tsx
+++ b/src/containers/contest/ContestDetail.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Dday from '@/components/common/Dday';
 import ActivityContestDetailTab from '@/components/common/ActivityContestDetailTab';
 import ActivityContestDescription from '@/components/common/ActivityContestDescription';
-import { formatDate } from '@/utils/format';
+import { formatDate, dateToFormatDate } from '@/utils/format';
 import { useState } from 'react';
 
 export default function ContestDetail({
@@ -22,7 +22,9 @@ export default function ContestDetail({
   target,
 }: ActivityContestDetail) {
   const [activeTab, setActiveTab] = useState('상세내용');
-  const [formatted_start_date, formatted_end_date] = [
+  const today_date = new Date();
+  const [formatted_today_date, formatted_start_date, formatted_end_date] = [
+    dateToFormatDate(today_date),
     formatDate(start_date),
     formatDate(end_date),
   ];
@@ -83,7 +85,17 @@ export default function ContestDetail({
         <ThumbnailImage url={thumbnail_url} title={title} isMobile={false} />
 
         <div className="flex-1">
-          <Dday type="active" day={d_day} color="red" />
+          {formatted_start_date > formatted_today_date ? (
+            <Dday type="upcoming" />
+          ) : formatted_end_date < formatted_today_date ? (
+            <Dday type="completed" />
+          ) : (
+            <Dday
+              type="active"
+              day={d_day}
+              color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'}
+            />
+          )}
           <h2 className="mb-2 mt-3 break-all text-2xl font-bold leading-normal text-sub-gray-500 md:text-5xl">
             {title}
           </h2>

--- a/src/containers/home/ActivityCardSlider.tsx
+++ b/src/containers/home/ActivityCardSlider.tsx
@@ -102,7 +102,7 @@ function ActivityCardSlider() {
         {currentItems.map((card) => (
           <Link
             key={card.id}
-            href={`/${card.main_category === '대외활동' ? 'activity' : 'contest'}/${card.id}`}
+            href={`/activity/${card.id}`}
           >
             <Card item={card} />
           </Link>

--- a/src/containers/home/ActivityCardSlider.tsx
+++ b/src/containers/home/ActivityCardSlider.tsx
@@ -8,25 +8,42 @@ import { fetchActivityCardSlider } from '@/lib/fetchActivityCardSlider';
 import Link from 'next/link';
 
 function Card({ item }: ContestActivityListProps) {
+  const today_date = new Date(); // 오늘 날짜
+  const [yearE, monthE, dayE] = item.end_date.split('.').map((part) => parseInt(part, 10));
+  const formattedEndDate = new Date(`20${yearE}-${monthE}-${dayE}`); // 마감 날짜
+  const [yearS, monthS, dayS] = item.start_date.split('.').map((part) => parseInt(part, 10));
+  const formattedStartDate = new Date(`20${yearS}-${monthS}-${dayS}`); // 시작 날짜
+
   return (
     <div id={`${item.id}`} className="overflow-hidden bg-white">
       <div className="relative h-48 w-full shadow-md">
-        <Image 
-          src={item.thumbnail_url} 
-          alt={item.title} 
-          fill 
-          objectFit="cover" 
-          className="rounded-xl" 
+        <Image
+          src={item.thumbnail_url}
+          alt={item.title}
+          fill
+          objectFit="cover"
+          className="rounded-xl"
         />
       </div>
-      <div className="p-1 flex flex-col h-[calc(100%-12rem)] min-h-[100px]">
-        <h3 className="h-11 pt-1 mb-3 line-clamp-2 text-base font-bold flex-grow">{item.title}</h3>
-        <div className="flex items-center justify-between mt-auto">
-          {item.d_day < 0 
-            ? <Dday type="completed" /> 
-            : <Dday type="active" day={item.d_day} color={item.d_day <= 7 ? 'red' : item.d_day <= 31 ? 'yellow' : 'green'} />
-          }
-          <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:font-medium md:text-sm lg:text-sm xl:text-base">
+      <div className="flex h-[calc(100%-12rem)] min-h-[100px] flex-col p-1">
+        <h3 className="mb-3 line-clamp-2 h-11 flex-grow pt-1 text-base font-bold">
+          {item.title}
+        </h3>
+        <div className="mt-auto flex items-center justify-between">
+          {formattedStartDate > today_date ? (
+            <Dday type="upcoming" />
+          ) : formattedEndDate < today_date ? (
+            <Dday type="completed" />
+          ) : (
+            <Dday
+              type="active"
+              day={item.d_day}
+              color={
+                item.d_day <= 7 ? 'red' : item.d_day <= 31 ? 'yellow' : 'green'
+              }
+            />
+          )}
+          <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:text-sm md:font-medium lg:text-sm xl:text-base">
             <span className="inline xl:hidden">{`~ ${item.end_date}`}</span>
             <span className="hidden xl:inline">{`${item.start_date} ~ ${item.end_date}`}</span>
           </p>
@@ -96,14 +113,9 @@ function ActivityCardSlider() {
 
   return (
     <section className="my-5 flex flex-col items-center gap-4">
-      <div 
-        className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-      >
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {currentItems.map((card) => (
-          <Link
-            key={card.id}
-            href={`/activity/${card.id}`}
-          >
+          <Link key={card.id} href={`/activity/${card.id}`}>
             <Card item={card} />
           </Link>
         ))}

--- a/src/containers/home/ContestCardSlider.tsx
+++ b/src/containers/home/ContestCardSlider.tsx
@@ -102,7 +102,7 @@ function ContestCardSlider() {
         {currentItems.map((card) => (
           <Link
             key={card.id}
-            href={`/${card.main_category === '대외활동' ? 'activity' : 'contest'}/${card.id}`}
+            href={`/contest/${card.id}`}
           >
             <Card item={card} />
           </Link>

--- a/src/containers/home/ContestCardSlider.tsx
+++ b/src/containers/home/ContestCardSlider.tsx
@@ -8,25 +8,42 @@ import { fetchContestCardSlider } from '@/lib/fetchContestCardSlider';
 import Link from 'next/link';
 
 function Card({ item }: ContestActivityListProps) {
+  const today_date = new Date(); // 오늘 날짜
+  const [yearE, monthE, dayE] = item.end_date.split('.').map((part) => parseInt(part, 10));
+  const formattedEndDate = new Date(`20${yearE}-${monthE}-${dayE}`); // 마감 날짜
+  const [yearS, monthS, dayS] = item.start_date.split('.').map((part) => parseInt(part, 10));
+  const formattedStartDate = new Date(`20${yearS}-${monthS}-${dayS}`); // 시작 날짜
+
   return (
     <div id={`${item.id}`} className="overflow-hidden bg-white">
       <div className="relative h-48 w-full shadow-md">
-        <Image 
-          src={item.thumbnail_url} 
-          alt={item.title} 
-          fill 
-          objectFit="cover" 
-          className="rounded-xl" 
+        <Image
+          src={item.thumbnail_url}
+          alt={item.title}
+          fill
+          objectFit="cover"
+          className="rounded-xl"
         />
       </div>
-      <div className="p-1 flex flex-col h-[calc(100%-12rem)] min-h-[100px]">
-        <h3 className="h-11 pt-1 mb-3 line-clamp-2 text-base font-bold flex-grow">{item.title}</h3>
-        <div className="flex items-center justify-between mt-auto">
-          {item.d_day < 0 
-            ? <Dday type="completed" /> 
-            : <Dday type="active" day={item.d_day} color={item.d_day <= 7 ? 'red' : item.d_day <= 31 ? 'yellow' : 'green'} />
-          }
-          <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:font-medium md:text-sm lg:text-sm xl:text-base">
+      <div className="flex h-[calc(100%-12rem)] min-h-[100px] flex-col p-1">
+        <h3 className="mb-3 line-clamp-2 h-11 flex-grow pt-1 text-base font-bold">
+          {item.title}
+        </h3>
+        <div className="mt-auto flex items-center justify-between">
+          {formattedStartDate > today_date ? (
+            <Dday type="upcoming" />
+          ) : formattedEndDate < today_date ? (
+            <Dday type="completed" />
+          ) : (
+            <Dday
+              type="active"
+              day={item.d_day}
+              color={
+                item.d_day <= 7 ? 'red' : item.d_day <= 31 ? 'yellow' : 'green'
+              }
+            />
+          )}
+          <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:text-sm md:font-medium lg:text-sm xl:text-base">
             <span className="inline xl:hidden">{`~ ${item.end_date}`}</span>
             <span className="hidden xl:inline">{`${item.start_date} ~ ${item.end_date}`}</span>
           </p>
@@ -96,14 +113,9 @@ function ContestCardSlider() {
 
   return (
     <section className="my-5 flex flex-col gap-4">
-      <div 
-        className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-      >
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {currentItems.map((card) => (
-          <Link
-            key={card.id}
-            href={`/contest/${card.id}`}
-          >
+          <Link key={card.id} href={`/contest/${card.id}`}>
             <Card item={card} />
           </Link>
         ))}

--- a/src/containers/home/HomeGridItem.tsx
+++ b/src/containers/home/HomeGridItem.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export default function HomeGridItem({ item }: ContestActivityListProps) {
   const {
-    id,
+    category_id,
     title,
     d_day,
     start_date,
@@ -17,7 +17,7 @@ export default function HomeGridItem({ item }: ContestActivityListProps) {
 
   return (
     <Link 
-      href={`${en_main_category}/${id}`} 
+      href={`${en_main_category}/${category_id}`} 
       className="relative block"
     >
       <div className="block sm:hidden w-full justify-center">

--- a/src/containers/home/HomeGridItem.tsx
+++ b/src/containers/home/HomeGridItem.tsx
@@ -13,7 +13,14 @@ export default function HomeGridItem({ item }: ContestActivityListProps) {
     main_category,
     thumbnail_url,
   } = item;
+
   const en_main_category = main_category === '공모전' ? 'contest' : 'activity';
+
+  const today_date = new Date();  // 오늘 날짜
+  const [yearE, monthE, dayE] = end_date.split('.').map((part) => parseInt(part, 10));
+  const formattedEndDate = new Date(`20${yearE}-${monthE}-${dayE}`); // 마감 날짜
+  const [yearS, monthS, dayS] = start_date.split('.').map((part) => parseInt(part, 10));
+  const formattedStartDate = new Date(`20${yearS}-${monthS}-${dayS}`); // 시작 날짜
 
   return (
     <Link 
@@ -52,9 +59,11 @@ export default function HomeGridItem({ item }: ContestActivityListProps) {
         </h2>
 
         <div className="flex items-center justify-between gap-1.5">
-          {d_day < 0
-          ? <Dday type="completed" />
-          : <Dday type="active" day={d_day} color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'} />
+          {formattedStartDate > today_date
+          ? <Dday type="upcoming" />
+          : formattedEndDate < today_date
+            ? <Dday type="completed" />
+            : <Dday type="active" day={d_day} color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'} />
           }
           <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:font-medium md:text-sm lg:text-sm xl:text-base">
             <span className="inline xl:hidden">{`~ ${end_date}`}</span>

--- a/src/containers/home/MainSlider.tsx
+++ b/src/containers/home/MainSlider.tsx
@@ -90,7 +90,7 @@ export default function MainSlider() {
                 </p>
               </div>
               <BannerLink
-                url={`/${content.main_category === '대외활동' ? 'activity' : 'contest'}/${content.id}`}
+                url={`/${content.main_category === '대외활동' ? 'activity' : 'contest'}/${content.category_id}`}
               />
             </div>
 

--- a/src/containers/home/MoMainSlider.tsx
+++ b/src/containers/home/MoMainSlider.tsx
@@ -59,7 +59,7 @@ export default function MoMainSlider() {
         <h2 className="text-base font-medium">
           {`[ ${contents[currentIndex]?.main_category} ]`}
         </h2>
-        <h1 className="h-20 line-clamp-2 mb-1 text-2xl font-bold leading-10 max-w-[70%]">
+        <h1 className="h-20 line-clamp-2 mb-1.5 text-2xl font-bold leading-10 w-[70%]">
           {contents[currentIndex]?.title}
         </h1>
         <BannerLink url={`/contest/${contents[currentIndex]?.id}`} />

--- a/src/lib/fetchBestPickGridView.ts
+++ b/src/lib/fetchBestPickGridView.ts
@@ -49,9 +49,8 @@ export const fetchBestPickAll = async (): Promise<{
 
   if (error) {
     console.error('fetchBestPickAll 데이터 가져오기 실패:', error);
-    return { data: null, error };
+    return { data: data || [], error, count: count || 0 };
   }
-
   // Date 형식 변경
   const formattedData = data.map((item) => {
     const formatToKoreanDate = (dateString: Date) => {
@@ -71,5 +70,5 @@ export const fetchBestPickAll = async (): Promise<{
     };
   });
 
-  return { data: formattedData, error: null, count: count || 0 };
+  return { data: formattedData, error, count: count || 0 };
 };

--- a/src/lib/fetchBestPickGridView.ts
+++ b/src/lib/fetchBestPickGridView.ts
@@ -44,7 +44,27 @@ export const fetchBestPickAll = async (): Promise<{
 
   if (error) {
     console.error('fetchBestPickAll 데이터 가져오기 실패:', error);
+    return { data: null, error };
   }
 
-  return { data, error };
+  // Date 형식 변경
+  const formattedData = data.map((item) => {
+    const formatToKoreanDate = (dateString: Date) => {
+      const date = new Date(dateString);
+      
+      return date.toLocaleDateString('ko-KR', {
+        year: '2-digit',
+        month: '2-digit',
+        day: '2-digit',
+      }).replace(/\./g, '').trim().replace(/ /g, '.');
+    };
+
+    return {
+      ...item,
+      start_date: formatToKoreanDate(item.start_date),
+      end_date: formatToKoreanDate(item.end_date),
+    };
+  });
+
+  return { data: formattedData, error: null };
 };

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -118,6 +118,8 @@ type ActivityContestData = {
   title: string;
   company: string;
   d_day: number;
+  start_date: string;
+  end_date: string;
   view_count: number;
   thumbnail_url: string;
 };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -5,3 +5,8 @@ export const formatViewCount = (count: number) => {
 };
 
 export const formatDate = (date: string) => format(parseISO(date), 'yy.MM.dd');
+
+export const dateToFormatDate = (date: Date) => {
+  // Date 객체를 받아 정해진 날짜 형식으로 변경.
+  return format(date, 'yy.MM.dd');
+};


### PR DESCRIPTION
## 변경 사항 설명
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요. -->
### 1. D-day 컴포넌트 조건부 렌더링 적용 ➡️ 홈 / 매거진 / 공모전 / 대외활동
<img width="1172" alt="Screenshot 2024-11-19 at 23 22 19" src="https://github.com/user-attachments/assets/00605590-74ac-4ccb-8199-7d58deab811b">

기존 코드에서도 디데이 값이 음수일 경우 `마감` 태그가 뜨게 설정해놓았으나, **애초에 데이터베이스에서 디데이 값이 음수로 설정되지 않아** 적용이 되지 않는 상태였습니다. 따라서 공고 시작 일자, 마감 일자, 오늘 날짜를 비교해 `마감` 태그는 물론 `예정` 태그도 경우에 맞게 렌더링되도록 코드를 수정하였습니다. 

#### 📁 format.ts
```tsx
// 기존에 있던 함수
export const formatDate = (date: string) => format(parseISO(date), 'yy.MM.dd');
// 새로 만든 함수
export const dateToFormatDate = (date: Date) => {
  // Date 객체를 받아 정해진 날짜 형식으로 변경.
  return format(date, 'yy.MM.dd');
};
```
또한 공모전, 대외활동 상세 페이지에서 날짜들을 비교할 때 날짜의 형식을 맞추기 위해 `dateToFormatDate` 함수를 추가하였고, 
<br/>

#### 📁 data.d.ts
```tsx
type ActivityContestData = {
  id: number;
  title: string;
  company: string;
  d_day: number;
  start_date: string;
  end_date: string;
  view_count: number;
  thumbnail_url: string;
};

type ActivityContestItemProps = {
  item: ActivityContestData;
};
```
공모전, 대외활동 상세 페이지에서 사용하는 `ActivityContestData` 타입에 날짜 관련 속성을 추가하였습니다. 

#### 📁 ActivityContestItem.tsx
```tsx
export default function ActivityContestItem({
  item,
}: ActivityContestItemProps) {
  const { id, title, company, d_day, start_date, end_date, view_count, thumbnail_url } = item;

  const pathname = usePathname();
  const category = pathname.split('/')[1];

  const detailUrl = useDetailUrl(id, category);

  const today_date = new Date();
  const [formatted_today_date, formatted_start_date, formatted_end_date] = [
    dateToFormatDate(today_date),
    formatDate(start_date),
    formatDate(end_date),
  ];

  return (
    <Link href={detailUrl} className="block w-full">
      <ThumbnailImage url={thumbnail_url} title={title} isMobile={true} />
      <ThumbnailImage url={thumbnail_url} title={title} isMobile={false} />

      <div className="mt-2 w-full md:mt-4">
        <h2 className="line-clamp-2 min-h-[3em] text-base font-semibold md:min-h-[3.9em] md:text-xl">
          {title}
        </h2>

        <p className="mb-2 line-clamp-1 text-sm font-normal text-sub-gray-400 md:text-xl md:font-medium">
          {company}
        </p>

        <div className="flex items-center gap-1.5">
          {formatted_start_date > formatted_today_date ? (
            <Dday type="upcoming" />
          ) : formatted_end_date < formatted_today_date ? (
            <Dday type="completed" />
          ) : (
            <Dday
              type="active"
              day={d_day}
              color={d_day <= 7 ? 'red' : d_day <= 31 ? 'yellow' : 'green'}
            />
          )}
          <p className="text-xs font-normal text-sub-gray-300 sm:text-sm md:text-base md:font-medium">
            조회 {formatViewCount(view_count)}회
          </p>
        </div>
      </div>
    </Link>
  );
}
```
위와 같이 오늘 날짜와 공고 시작일, 공고 마감일을 추출 및 타입 변경하여 디데이 컴포넌트를 조건부 렌더링되게 하였습니다. 

<img width="600" alt="Screenshot 2024-11-19 at 23 31 13" src="https://github.com/user-attachments/assets/56eb239c-f38b-4c2d-a001-b22d1a4c0447">
<img width="1174" alt="Screenshot 2024-11-20 at 00 08 20" src="https://github.com/user-attachments/assets/fbc629bd-0534-48e6-a3ad-e89398c95f1f">

위와 같이 홈의 모든 컴포넌트들, 매거진 페이지나 공모전, 대외활동 상세 페이지 등에서도 확인하실 수 있습니다. 
<br/>

### 2. 매거진 페이지 날짜 형식 변경
<img width="583" alt="Screenshot 2024-11-19 at 23 38 50" src="https://github.com/user-attachments/assets/5e177e0e-d08f-4213-af3c-92074a21e935">

이를 위해 매거진 페이지에서 사용하는 fetch 함수를 수정하였습니다.
<br/>

### 3. 데이터베이스 속성 변경에 따른 홈의 컴포넌트들의 id 값 수정
#### Ex> 📁 HomeGridItem.tsx 
```tsx
  return (
    <Link 
      href={`${en_main_category}/${category_id}`} 
      className="relative block"
    >
  );
```

공고에 맞는 상세 페이지로 넘어가게 하기 위해 `id` 값을 `category_id` 값으로 수정하였습니다. 
<br/>

### 4. etc.
이외에도 각종 css 수정 등의 리팩토링을 진행하였습니다. 
<br/>

## 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. (예: #123) -->
#85 

## 변경 유형
- [X] 버그 수정
- [X] 새로운 기능
- [X] 리팩토링 (기능 변경 없음)

## 체크리스트
<!--PR 체크리스트에 어떤 내용이 들어가면 좋을지 논의해 봅시다.-->

- [X] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [X] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
<!-- PR에 대한 추가 정보나 스크린샷이 있다면 여기에 추가해주세요. -->
스켈레톤 적용은 아직 못해본 상태! 2차 리팩토링 마무리 후 진행해보도록 하겠습니다 🫡
